### PR TITLE
[FIX]: Debugged exception handler's custom message to init

### DIFF
--- a/exception_handler.py
+++ b/exception_handler.py
@@ -6,5 +6,5 @@ class APIError(Exception):
     message: The eerror message passed to the exception.
     """
     def __init__(self, status, message):
-        self.custom_message = f"Status: {status}. Message: {message}"
-        super().__init__()
+        custom_message = f"Status: {status}. Message: {message}"
+        super().__init__(custom_message)


### PR DESCRIPTION
# Problem

Custom massage was not caught correctly by super.

# Solution

Pass custom_message to super()