### PR TITLE
Fix #64: Correct typos in README template title

### DIFF
--- a/app/templates/README.md.j2
+++ b/app/templates/README.md.j2
@@ -1,7 +1,7 @@
-# Goood First Issues :palm_tree:
+# Good First Issues :palm_tree:
 
 This page contains open issues tagged with the label *good first issue*. It gathers issues from some famous libraries(at least for me).
-Let me knowif there are others you would like to see here :pizza:
+Let me know if there are others you would like to see here :pizza:
 
 `update_issues.py` can  be modified to  return the data in json or to csv. 
 To run the script locally:


### PR DESCRIPTION
This PR fixes #64 by correcting typos in .

**Changes:**
- Fix heading: "Goood" → "Good"
- Fix spacing: "knowif" → "know if"

Fix was generated with AI assistance.