### PR TITLE
Separate how-it-works documentation from README template

### DIFF
--- a/app/templates/README.md.j2
+++ b/app/templates/README.md.j2
@@ -3,15 +3,7 @@
 This page contains open issues tagged with the label *good first issue*. It gathers issues from some famous libraries(at least for me).
 Let me know if there are others you would like to see here :pizza:
 
-## How it Works
-
-This project automates the discovery of good first-issues using GitHub API:
-
-* **Smart Discovery**: `RepoManager` identifies all public repositories from the usernames defined in your `.env` file.
-* **Issue Filtering**: `IssueManager` searches those repositories for issues labeled with `good first issue`.
-* **Language Matchmaking**: It identifies the primary language of each repository to help you find tasks in your area of expertise.
-* **Automated Rendering**: Uses **Jinja2** templates and the `TemplateManager` to render the gathered data into this README file.
-* **Daily Updates**: A GitHub Action runs the `update_issues.py` script daily to ensure the list is always updated.
+For more details, see [How It Works](docs/how-it-works.md).
 
 ## Local Setup
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,9 @@
+## How it Works
+
+This project automates the discovery of good first-issues using GitHub API:
+
+* **Smart Discovery**: `RepoManager` identifies all public repositories from the usernames defined in your `.env` file.
+* **Issue Filtering**: `IssueManager` searches those repositories for issues labeled with `good first issue`.
+* **Language Matchmaking**: It identifies the primary language of each repository to help you find tasks in your area of expertise.
+* **Automated Rendering**: Uses **Jinja2** templates and the `TemplateManager` to render the gathered data into this README file.
+* **Daily Updates**: A GitHub Action runs the `update_issues.py` script daily to ensure the list is always updated.


### PR DESCRIPTION
## Changes made

* Created `docs/how-it-works.md`
* Moved the "How it Works" section from the README template
* Added a link to the new documentation file in the README template

Closes #68
