### PR TITLE
[FEATURE]: Add action.yml for reusabile GitHub Actions outside the repo.

### DIFF
--- a/.github/workflows/update-issues.yml
+++ b/.github/workflows/update-issues.yml
@@ -1,37 +1,34 @@
-# .github/workflows/update-readme.yml
-
-name: "Update Good First Issues README"
+name: "Update Good First Issues"
 
 on:
   schedule:
-    - cron: '15 20 * * *' 
+    - cron: '15 20 * * *'
   push:
     branches:
       - 'main'
+  workflow_dispatch:
+
 permissions:
   contents: write
+
 jobs:
   update-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+
+      - uses: drkrillo/good-first-issues@main
         with:
-          python-version: '3.8'
-      - name: Install dependencies
+          usernames: ${{ secrets.USERNAMES }}
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+      - name: Update README
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run Python script
-        env:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          USERNAMES: ${{ secrets.USERNAMES }}
-        run: python -m app.update_issues --output good_first_issues.csv
+          pytnon -m app.update_issues --output good_first_issues.csv
+
       - name: Commit and push
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add README.md
-          git add good_first_issues.csv
-          git commit -m "Update README.md & issues.csv with dynamic content"
+          git add README.md good_first_issues.csv
+          git diff --staged --quiet || git commit -m "chore: update good first issues"
           git push origin main

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.secrets

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,55 @@
+name: 'Good First Issues'
+description: 'Fetch good first issues from GitHub repos, can generate a CSV/JSON output'
+author: 'drkrillo'
+
+inputs:
+  usernames:
+    description: 'Comma-separated list of GitHub usernames/orgs'
+    required: false
+    default: ''
+  output-format:
+    description: 'Output format: json or csv'
+    required: false
+    default: 'csv'
+  output-path:
+    description: 'Where to write the output file'
+    required: false
+    default: 'good_first_issues.csv'
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ github.action_path }}/requirements.txt
+
+    - name: Fetch issues
+      shell: bash
+      env:
+        ACCESS_TOKEN: ${{ inputs.github-token }}
+        USERNAMES: ${{ inputs.usernames }}
+        REPOS: ${{ inputs.repos }}
+        LANGUAGES: ${{ inputs.languages }}
+        OUTPUT_FORMAT: ${{ inputs.output-format }}
+        OUTPUT_PATH: ${{ inputs.output-path }}
+      run: |
+        python -m app.update_issues \
+        --output ${{ inputs.output-path }}
+      working-directory: ${{ github.action_path }}
+    - name: Commit and push
+      shell: bash
+      run: |
+        git config user.name github-actions
+        git config user.email
+        git add ${{ inputs.output-path }}
+        git diff --staged --quiet || git commit -m "chore: update good first issues"
+        git push origin main

--- a/app/core/api_handler.py
+++ b/app/core/api_handler.py
@@ -1,3 +1,4 @@
+import csv
 import math 
 import requests
 from jinja2 import Environment, FileSystemLoader
@@ -124,12 +125,25 @@ class TemplateManager:
         return sorted_formatted_results
     
     @staticmethod
-    def render_template(results, template_path, today):
+    def render_template(csv_path, template_path, today):
         """
-        Takes a jinja2 environment, template, results and today date
+        Takes a template, csv_path and today date
         and returns the rendered template.
         """
-        env = Environment(loader=FileSystemLoader(template_path))
+        results = []
+
+        with open(csv_path, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                results.append({
+                    'repo':     row['repo'],
+                    'language': row['language'],
+                    'title':    row['title'],
+                    'url':      row['url'],
+                    'comments': row['comments'],
+                })
+
+            env = Environment(loader=FileSystemLoader(template_path))
         
         template = env.get_template('README.md.j2')
         rendered_readme = template.render(results=results, today=today)

--- a/app/render_readme.py
+++ b/app/render_readme.py
@@ -1,0 +1,21 @@
+import argparse
+from datetime import datetime
+
+from app.core.api_handler import TemplateManager
+from app.core.config import get_template_path
+
+
+today = str(datetime.datetime.today().strftime('%Y-%m-%d'))
+template_path = get_template_path()
+
+if "__main__" == __name__:
+
+    parser = argparse.ArgumentParser(description='Find Good First Issues')
+    parser.add_argument('--output', help='Output file path (e.g. issues.csv or issues.json)')
+    args = parser.parse_args()
+    
+    TemplateManager.render_template(
+    csv_path=args.output,
+    template_path=template_path,
+    today=today,
+)

--- a/app/update_issues.py
+++ b/app/update_issues.py
@@ -24,9 +24,6 @@ from app.core.api_handler import (
 )
 
 
-today = str(datetime.datetime.today().strftime('%Y-%m-%d'))
-template_path = get_template_path()
-
 def write_output(issues, output_file):
     """Write issues to a file in CSV or JSON format."""
     ext = output_file.lower().split('.')[-1]
@@ -67,16 +64,8 @@ def main(args):
         formatted_response = TemplateManager.format_response(issues)
 
         if args.output:
-            write_output(issues, args.output)
+            write_output(formatted_response, args.output)
             logging.info(f"Wrote {len(issues)} issues to {args.output}")
-
-        logging.info(f"Formatted issues first row: {formatted_response[0]}")
-        
-        TemplateManager.render_template(
-            results=formatted_response,
-            template_path=template_path,
-            today=today,
-        )
 
         logging.info(f"Rendered README file.")
         logging.info(f"Total repositories gathered: {len(repos)}")        


### PR DESCRIPTION
# Problem

- The GitHub actions was made for usning inside good-first-issue alone.
- There was no action.yml to reuse outside the repo.
- The workflow generated dynamic README as part of the main workflow, making it difficult to use it as is outside of it.

# Solution

- Add an action.yml to serve as a generalized way of using the Action workflow.
- Now, the main output of the Action workflow is a csv.
- Created a separed script for dynamic creation f the README (used in this repo) that uses the previously created CSV.