### PR TITLE
 Optimize API calls using Search API and language caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,261 +29,126 @@ If you are wondering where to begin in the  journey contributing to open-source 
 
 
 
-## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-07</sub></sub>
+## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-09</sub></sub>
 
 | Repo | Language | Title | Comments |
 | --- | --- | --- | --- |
-| pytorch/glow | C++ | [[TensorLayout] Add a way to specify canonical layout propagation to NodeGen](https://github.com/pytorch/glow/issues/3834) | 0 |
-| pytorch/glow | C++ | [[Runtime] Expand Yaml DeviceConfig loading to include HostConfig](https://github.com/pytorch/glow/issues/3079) | 0 |
-| pytorch/glow | C++ | [[runtime] add device memory size configuration to the DeviceConfig::parameters map on all backends](https://github.com/pytorch/glow/issues/2899) | 0 |
-| pytorch/glow | C++ | [resnet-* example code should reuse Tensor memory for images](https://github.com/pytorch/glow/issues/2898) | 0 |
-| pytorch/glow | C++ | [Example binaries should handle HostManager active request limit](https://github.com/pytorch/glow/issues/2816) | 0 |
-| pytorch/glow | C++ | [[ONNXIFI] Add additional precondition checks to model loaders](https://github.com/pytorch/glow/issues/2188) | 0 |
-| pytorch/glow | C++ | [[ONNXIFI][GraphAPI] Add "orErr" methods for graph creation api](https://github.com/pytorch/glow/issues/2187) | 0 |
-| pytorch/glow | C++ | [ConvBench should use the layers of ResNet](https://github.com/pytorch/glow/issues/1887) | 0 |
-| pytorch/glow | C++ | [ConvBench should use libjit_convolution_D8KKC8](https://github.com/pytorch/glow/issues/1886) | 0 |
-| pytorch/xla | C++ | [Op info test for `bmm .. ceil`](https://github.com/pytorch/xla/issues/7546) | 0 |
-| pytorch/xla | C++ | [Op info test for `rsub .. searchsorted`](https://github.com/pytorch/xla/issues/7532) | 0 |
-| pytorch/xla | C++ | [Op info test for `norm .. pca_lowrank`](https://github.com/pytorch/xla/issues/7528) | 0 |
-| pytorch/xla | C++ | [Op info test for `nn.functional.softmin .. nonzero_static`](https://github.com/pytorch/xla/issues/7527) | 0 |
-| pytorch/xla | C++ | [Op info test for `nn.functional.group_norm .. nn.functional.layer_norm`](https://github.com/pytorch/xla/issues/7522) | 0 |
-| pytorch/xla | C++ | [Op info test for `nn.functional.conv_transpose3d .. nn.functional.ctc_loss`](https://github.com/pytorch/xla/issues/7519) | 0 |
-| pytorch/xla | C++ | [Op info test for `linalg.ldl_factor_ex`](https://github.com/pytorch/xla/issues/7487) | 0 |
-| pytorch/xla | C++ | [Op info test for `linalg.householder_product`](https://github.com/pytorch/xla/issues/7483) | 0 |
-| pytorch/xla | C++ | [Op info test for `linalg.cholesky_ex`](https://github.com/pytorch/xla/issues/7463) | 0 |
-| pytorch/xla | C++ | [Op info test for `linalg.cholesky`](https://github.com/pytorch/xla/issues/7462) | 0 |
-| canonical/mir | C++ | [Move from `snprintf` and friends to `std::format*` and add checks for truncation](https://github.com/canonical/mir/issues/4549) | 0 |
-| canonical/mir | C++ | [The MirAL API should support more options for display configuration](https://github.com/canonical/mir/issues/4184) | 0 |
-| canonical/mir | C++ | [Review the symbol generator's hidden symbols list](https://github.com/canonical/mir/issues/4094) | 0 |
-| canonical/mir | C++ | [`grimshot save output` captures all outputs, not just the active one](https://github.com/canonical/mir/issues/4014) | 0 |
-| canonical/mir | C++ | [Unify mousekeys/mouse keys naming](https://github.com/canonical/mir/issues/3901) | 0 |
-| canonical/mir | C++ | [Read current display mode as default](https://github.com/canonical/mir/issues/3179) | 0 |
-| canonical/mir | C++ | [Driver probe should check for presence of Wayland extension](https://github.com/canonical/mir/issues/2288) | 0 |
-| canonical/mir | C++ | [CompositorPerformance test uses its own idiosyncratic server runner](https://github.com/canonical/mir/issues/1653) | 0 |
-| canonical/mir | C++ | [We're missing a way for Mir to report the socket it selects](https://github.com/canonical/mir/issues/1398) | 0 |
-| canonical/multipass | C++ | [[snapshot] Lack of interactive stdin causes unhandled exception on `multipass restore`](https://github.com/canonical/multipass/issues/4825) | 0 |
-| canonical/wlcs | C++ | [`xdg_toplevel_stable.cpp` cleanups](https://github.com/canonical/wlcs/issues/406) | 0 |
-| pytorch/glow | C++ | [[CPU] Remove the need for Rescale for the CPUMaxSplat](https://github.com/pytorch/glow/issues/4656) | 1 |
-| pytorch/xla | C++ | [xs.make_mesh](https://github.com/pytorch/xla/issues/8838) | 1 |
-| pytorch/xla | C++ | [torch_xla scan forces inputs to be differentiable](https://github.com/pytorch/xla/issues/8783) | 1 |
-| pytorch/xla | C++ | [[torch_xla] scan_layers fails if the layer have no weights](https://github.com/pytorch/xla/issues/8748) | 1 |
-| pytorch/xla | C++ | [[hard] Op info test for `special.airy_ai`](https://github.com/pytorch/xla/issues/7926) | 1 |
-| pytorch/xla | C++ | [Op info test for `triangular_solve .. unfold`](https://github.com/pytorch/xla/issues/7541) | 1 |
-| pytorch/xla | C++ | [Op info test for `nn.functional.pixel_shuffle .. nn.functional.scaled_dot_product_attention`](https://github.com/pytorch/xla/issues/7526) | 1 |
-| pytorch/xla | C++ | [Op info test for `linalg.matrix_norm`](https://github.com/pytorch/xla/issues/7494) | 1 |
-| pytorch/xla | C++ | [Op info test for `linalg.lu_factor_ex`](https://github.com/pytorch/xla/issues/7492) | 1 |
-| pytorch/xla | C++ | [Op info test for `linalg.lu_factor`](https://github.com/pytorch/xla/issues/7491) | 1 |
-| pytorch/xla | C++ | [Op info test for `index_reduce`](https://github.com/pytorch/xla/issues/7453) | 1 |
-| pytorch/xla | C++ | [[hard] Op info test for `histogramdd`](https://github.com/pytorch/xla/issues/7445) | 1 |
-| canonical/mir | C++ | [Add `wl_array` wrapper](https://github.com/canonical/mir/issues/4159) | 1 |
-| canonical/mir | C++ | [manpages & help](https://github.com/canonical/mir/issues/1610) | 1 |
-| canonical/multipass | C++ | [[snapshot] Raw error on snapshot deletion attempt on a running VM](https://github.com/canonical/multipass/issues/4824) | 1 |
-| canonical/multipass | C++ | [[sshfs] Multipass logs leaking filepaths from CI environments](https://github.com/canonical/multipass/issues/4195) | 1 |
-| pytorch/glow | C++ | [New files added under glow/test/models/ don't get copied to build folder until clean build is performed.](https://github.com/pytorch/glow/issues/4647) | 2 |
-| pytorch/glow | C++ | [Make all useful data structures in Glow easy to dump in a textual form](https://github.com/pytorch/glow/issues/2831) | 2 |
-| pytorch/glow | C++ | [[Importers] Move "run and compare" tests from importer tests to operator tests](https://github.com/pytorch/glow/issues/1909) | 2 |
-| pytorch/glow | C++ | [Need to canonicalize or optimize high-dim concat to concat+transpose](https://github.com/pytorch/glow/issues/1296) | 2 |
-| pytorch/xla | C++ | [Op info test for `special.scaled_modified_bessel_k0 .. squeeze`](https://github.com/pytorch/xla/issues/7538) | 2 |
-| pytorch/xla | C++ | [Op info test for `nn.functional.feature_alpha_dropout .. nn.functional.grid_sample`](https://github.com/pytorch/xla/issues/7521) | 2 |
-| pytorch/xla | C++ | [Op info test for `linalg.matrix_power`](https://github.com/pytorch/xla/issues/7495) | 2 |
-| pytorch/xla | C++ | [Op info test for `linalg.ldl_solve`](https://github.com/pytorch/xla/issues/7488) | 2 |
-| canonical/mir | C++ | [Support for natural (inversed) scrolling in the input configuration](https://github.com/canonical/mir/issues/4622) | 2 |
-| canonical/mir | C++ | [Pointer/touchpad acceleration bias configuration values not loaded at startup](https://github.com/canonical/mir/issues/4605) | 2 |
-| canonical/mir | C++ | [`MinimalWindowManager` should reposition windows to an active output when their output is removed](https://github.com/canonical/mir/issues/3895) | 2 |
-| canonical/multipass | C++ | [firewalld integration](https://github.com/canonical/multipass/issues/1236) | 2 |
-| pytorch/glow | C++ | [Move layout information from nodes constructor' to their Glow types](https://github.com/pytorch/glow/issues/3790) | 3 |
-| pytorch/glow | C++ | [[habana] Implement backend specific verifications](https://github.com/pytorch/glow/issues/3480) | 3 |
-| pytorch/xla | C++ | [Op info test for `nn.functional.leaky_relu .. nn.functional.max_pool1d`](https://github.com/pytorch/xla/issues/7523) | 3 |
-| pytorch/xla | C++ | [Op info test for `kthvalue`](https://github.com/pytorch/xla/issues/7458) | 3 |
-| tensorflow/minigo | C++ | [Support more GTP commands](https://github.com/tensorflow/minigo/issues/46) | 3 |
-| canonical/mir | C++ | [`gmtime` and `localtime` are not thread safe and are outdated](https://github.com/canonical/mir/issues/4552) | 3 |
-| canonical/mir | C++ | [Add support for `orientation: [vh]-mirrored`](https://github.com/canonical/mir/issues/3908) | 3 |
-| canonical/multipass | C++ | [[virtualbox@macOS] Purge-uninstall leaves VMs behind](https://github.com/canonical/multipass/issues/3571) | 3 |
-| pytorch/glow | C++ | [[GraphOptz] Sink Quantize below Reshape](https://github.com/pytorch/glow/issues/4629) | 4 |
-| pytorch/xla | C++ | [Op info test for `pinverse .. put`](https://github.com/pytorch/xla/issues/7529) | 4 |
-| pytorch/xla | C++ | [Op info test for `nn.functional.avg_pool1d .. nn.functional.bilinear`](https://github.com/pytorch/xla/issues/7517) | 4 |
-| pytorch/xla | C++ | [Op info test for `linalg.lu_solve`](https://github.com/pytorch/xla/issues/7493) | 4 |
-| canonical/mir | C++ | [Send proper make and model information for `wl_output::geometry`](https://github.com/canonical/mir/issues/4061) | 4 |
-| canonical/mir | C++ | [WindowManager::add_display()/remove_display()](https://github.com/canonical/mir/issues/2148) | 4 |
-| canonical/multipass | C++ | [Ability to choose terminal emulator multipass.gui](https://github.com/canonical/multipass/issues/899) | 4 |
-| canonical/multipass | C++ | [Handle yaml-cpp exceptions from a cloud-init config better](https://github.com/canonical/multipass/issues/646) | 4 |
-| canonical/multipass | C++ | [Suggest opening up firewall when launching times out](https://github.com/canonical/multipass/issues/533) | 4 |
-| pytorch/glow | C++ | [Fuse RescaleQuantized in the ChannelwiseQuantizedConv](https://github.com/pytorch/glow/issues/4928) | 5 |
-| pytorch/glow | C++ | [Bring back the sinking RELU below Pool optimization](https://github.com/pytorch/glow/issues/3247) | 5 |
-| pytorch/glow | C++ | [Use gtest-parallel](https://github.com/pytorch/glow/issues/2412) | 5 |
-| canonical/mir | C++ | [Replace `str(n)?cmp` with `std::string_view::operator==`](https://github.com/canonical/mir/issues/4567) | 5 |
-| canonical/multipass | C++ | [Use host apt proxy configuration](https://github.com/canonical/multipass/issues/818) | 5 |
-| canonical/multipass | C++ | [Instrument function calls to debug-log arguments and return values](https://github.com/canonical/multipass/issues/428) | 5 |
-| pytorch/glow | C++ | [Glow should provide its own implementation of a random number generator to ensure deterministic testing and avoid platform-dependent differences](https://github.com/pytorch/glow/issues/1556) | 6 |
-| canonical/multipass | C++ | [Error "launch failed: Remote "release" is unknown or unreachable. If image mirror is enabled, please confirm it is valid." when launching image too quickly after installing Multipass](https://github.com/canonical/multipass/issues/3723) | 6 |
-| canonical/multipass | C++ | [New GUI doesn't respect theme](https://github.com/canonical/multipass/issues/3608) | 7 |
-| godotengine/godot | C++ | [Polygon2D's bug. disappear or don't render.](https://github.com/godotengine/godot/issues/117960) | 8 |
-| pytorch/glow | C++ | [Make the execution of the Glow compiler more deterministic between multiple runs](https://github.com/pytorch/glow/issues/1948) | 9 |
-| canonical/multipass | C++ | [Unify VM resource minima in Daemon/CLI/GUI](https://github.com/canonical/multipass/issues/3777) | 9 |
-| canonical/multipass | C++ | [Allow specifying wildcards (`*`) for `--[ug]id-map` on mounts](https://github.com/canonical/multipass/issues/1200) | 10 |
-| canonical/multipass | C++ | [Bulk operations - Ability to perform actions on multiple nodes](https://github.com/canonical/multipass/issues/2404) | 11 |
-| canonical/multipass | C++ | [Issues with 3rd party compilation order](https://github.com/canonical/multipass/issues/3802) | 12 |
-| pytorch/glow | C++ | [[ONNXModelLoader] Support for LogSoftmax operator is missing](https://github.com/pytorch/glow/issues/4399) | 16 |
-| pytorch/glow | C++ | [Use explicit std::string conversions instead of implicit llvm::StringRef->std::string conversions to prepare Glow for builds using LLVM >=11](https://github.com/pytorch/glow/issues/5068) | 18 |
-| godotengine/godot | C++ | [[Godot v4.4] Gizmos exponentially increasing Draw Calls and Objects when turned on](https://github.com/godotengine/godot/issues/103676) | 24 |
-| godotengine/godot | C++ | [You're breathtaking!](https://github.com/godotengine/godot/issues/100000) | 34 |
-| godotengine/godot | C++ | [[TRACKER] Unit tests to add or improve](https://github.com/godotengine/godot/issues/43440) | 250 |
-| canonical/ulwazi | CSS | [Cookie consent banner fails to show](https://github.com/canonical/ulwazi/issues/91) | 0 |
-| canonical/ulwazi | CSS | [Weirdly looking code blocks captions](https://github.com/canonical/ulwazi/issues/78) | 0 |
-| canonical/ulwazi | CSS | [Font size of numbers in numerated lists seems too big](https://github.com/canonical/ulwazi/issues/81) | 1 |
-| canonical/jepsen.dqlite | Clojure | [Use go-dqlite's TLS connections](https://github.com/canonical/jepsen.dqlite/issues/103) | 0 |
-| ansible/pylibssh | Cython | [[TODO] Ensure release builds don't include debug symbols](https://github.com/ansible/pylibssh/issues/767) | 0 |
-| godotengine/emacs-gdscript-mode | Emacs Lisp | [Rewrite gdscript-imenu to provide GDScript-specific tables](https://github.com/godotengine/emacs-gdscript-mode/issues/89) | 0 |
-| godotengine/emacs-gdscript-mode | Emacs Lisp | [Buffer does not revert or update instantly after formatting buffer](https://github.com/godotengine/emacs-gdscript-mode/issues/88) | 3 |
-| godotengine/godot-benchmarks | GDScript | [[Call to Action] Benchmarks for the benchmark server](https://github.com/godotengine/godot-benchmarks/issues/36) | 5 |
-| godotengine/godot-benchmarks | GDScript | [[TRACKER] Benchmarks to create](https://github.com/godotengine/godot-benchmarks/issues/11) | 11 |
-| ansible/receptor | Go | [append conntype string representation in status output](https://github.com/ansible/receptor/issues/423) | 0 |
-| canonical/etrace | Go | [error message should be smarter](https://github.com/canonical/etrace/issues/28) | 0 |
-| canonical/etrace | Go | [fail with nicer message when no window session is available](https://github.com/canonical/etrace/issues/27) | 0 |
-| canonical/etrace | Go | [doesn't complain when prepare/restore scripts are not executable](https://github.com/canonical/etrace/issues/4) | 0 |
-| canonical/lxd | Go | [Auth: Support CLI when OIDC client secret is configured](https://github.com/canonical/lxd/issues/17871) | 0 |
-| canonical/microcloud | Go | [Terminate preseed joiners when initiator exits](https://github.com/canonical/microcloud/issues/597) | 0 |
-| ansible/receptor | Go | [add work status command to receptorctl](https://github.com/ansible/receptor/issues/374) | 1 |
-| ansible/terraform-provider-ansible | Go | [ansible_playbook_run doesn't accept variable](https://github.com/ansible/terraform-provider-ansible/issues/154) | 1 |
-| canonical/microceph | Go | [`microceph disk list` shows un-supported disks as well](https://github.com/canonical/microceph/issues/243) | 1 |
-| ansible/receptor | Go | [quality of life -- order work list output based on most recent work units](https://github.com/ansible/receptor/issues/425) | 2 |
-| canonical/lxd | Go | [lxc image filters do not match displayed values](https://github.com/canonical/lxd/issues/17272) | 2 |
-| canonical/lxd | Go | [Add custom volume transfer to lxd-migrate](https://github.com/canonical/lxd/issues/11558) | 2 |
-| canonical/lxd | Go | [Add `wait_ready` nic config keys for IPv4/IPv6 routes](https://github.com/canonical/lxd/issues/11535) | 2 |
-| canonical/microceph | Go | [Cannot enable SSO on Ceph Dashboard (missing python3-saml)](https://github.com/canonical/microceph/issues/397) | 2 |
-| canonical/microceph | Go | [MicroCeph: Replace :doc: with :ref: targets for internal cross-reference links](https://github.com/canonical/microceph/issues/605) | 3 |
-| canonical/microceph | Go | [Fault enabling replication](https://github.com/canonical/microceph/issues/559) | 4 |
-| canonical/lxd | Go | [Can't select name column when filtering by IP](https://github.com/canonical/lxd/issues/17055) | 5 |
-| canonical/lxd | Go | [Add lxc config device add disk --type=block for containers ](https://github.com/canonical/lxd/issues/10077) | 20 |
-| canonical/charmed-temporal-solutions | HCL | [Switch PostgreSQL charm channel to 16/stable once released](https://github.com/canonical/charmed-temporal-solutions/issues/12) | 2 |
-| canonical/packer-maas | HCL | [feat: add pve8.4 packer configs](https://github.com/canonical/packer-maas/pull/317) | 15 |
-| django/birthday20 | HTML | [Add social media links on event pages](https://github.com/django/birthday20/issues/101) | 3 |
-| django/birthday20 | HTML | [Vendor third-party assets (leaflet)](https://github.com/django/birthday20/issues/70) | 10 |
-| pytorch/serve | Java | [The captum for bert notebook needs update](https://github.com/pytorch/serve/issues/1317) | 0 |
-| pytorch/serve | Java | [Enable naked DIR test case for windows environment](https://github.com/pytorch/serve/issues/882) | 0 |
-| pytorch/serve | Java | [[Educational] Typing `.py` files iteratively with mypy](https://github.com/pytorch/serve/issues/1512) | 1 |
-| pytorch/serve | Java | [Built-in handler for regression](https://github.com/pytorch/serve/issues/987) | 1 |
-| pytorch/serve | Java | [permission error while trying to remove previous artifact files in `/tmp/`](https://github.com/pytorch/serve/issues/1532) | 3 |
-| pytorch/serve | Java | [Torchserve M1 support detailed plan](https://github.com/pytorch/serve/issues/2555) | 4 |
-| pytorch/serve | Java | [add support for SeTFiT models](https://github.com/pytorch/serve/issues/2107) | 4 |
-| pytorch/serve | Java | [[BUG] Dockerfile with nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 gives ascii codec error](https://github.com/pytorch/serve/issues/821) | 4 |
-| pytorch/serve | Java | [how does `default_response_timeout` work?](https://github.com/pytorch/serve/issues/2452) | 6 |
-| pytorch/serve | Java | [[Suggestion] Loading torch-model-archiver arguments from YAML](https://github.com/pytorch/serve/issues/780) | 6 |
-| pytorch/serve | Java | [Handle invalid input intelligently ！](https://github.com/pytorch/serve/issues/2459) | 7 |
-| pytorch/ci-hud | JavaScript | [Restore "Show service jobs" checkbox to GitHubStatusDisplay.js ](https://github.com/pytorch/ci-hud/issues/110) | 2 |
-| huggingface/transformers.js | JavaScript | [Is 'aggregation_strategy' parameter available for token classification pipeline?](https://github.com/huggingface/transformers.js/issues/633) | 2 |
-| huggingface/transformers.js | JavaScript | [[Feature request] Return offset mapping using tokenizer](https://github.com/huggingface/transformers.js/issues/425) | 2 |
-| huggingface/transformers.js | JavaScript | [[Doc request] Add an example guide of how to use it in Svelte (and deploy to HF Spaces)](https://github.com/huggingface/transformers.js/issues/171) | 7 |
-| ansible/galaxy_collection | Jinja | [Replace order of roles](https://github.com/ansible/galaxy_collection/issues/396) | 0 |
-| canonical/seldon-core-operator | Jinja | [Add test that uses istio ingress](https://github.com/canonical/seldon-core-operator/issues/19) | 0 |
-| ansible/awx-operator | Jinja | [Add multi-arch build target](https://github.com/ansible/awx-operator/issues/1680) | 1 |
-| ansible/product-demos | Jinja | [Add teardown template/workflow for "Deploy Cloud Stack in AWS" workflow](https://github.com/ansible/product-demos/issues/192) | 1 |
-| ansible/awx-operator | Jinja | [annotations not applied to postgres statefulset](https://github.com/ansible/awx-operator/issues/1624) | 2 |
-| ansible/awx-operator | Jinja | [Inflated Total Host Count on Dashboard when Using Constructed Inventory with Existing Inventories](https://github.com/ansible/awx-operator/issues/1459) | 2 |
-| ansible/awx-operator | Jinja | [Extend README with external logging examples](https://github.com/ansible/awx-operator/issues/1086) | 2 |
-| ansible/awx-operator | Jinja | [Inability to overwrite namespace when using awx-operator chart](https://github.com/ansible/awx-operator/issues/999) | 3 |
-| ansible/awx-operator | Jinja | [Password set via UI gets overwritten by initialize_django playbook](https://github.com/ansible/awx-operator/issues/869) | 5 |
-| tensorflow/probability | Jupyter Notebook | [providing sample weights to glm.fit() and glm.fit.sparse()](https://github.com/tensorflow/probability/issues/252) | 0 |
-| tensorflow/probability | Jupyter Notebook | [Sigmoid belief network example/tutorial](https://github.com/tensorflow/probability/issues/70) | 0 |
-| tensorflow/probability | Jupyter Notebook | [Logistic factorial analysis example/tutorial](https://github.com/tensorflow/probability/issues/68) | 0 |
-| tensorflow/swift-models | Jupyter Notebook | [Add documentation to the Gym models to specify additional dependencies for DQN](https://github.com/tensorflow/swift-models/issues/657) | 0 |
-| tensorflow/swift-models | Jupyter Notebook | [[BERT-CoLA]: Use common file extraction functions](https://github.com/tensorflow/swift-models/issues/489) | 0 |
-| tensorflow/swift-models | Jupyter Notebook | [Verify BERT variants](https://github.com/tensorflow/swift-models/issues/433) | 0 |
-| canonical/charmed-kubeflow-uats | Jupyter Notebook | [Perform cleanup at the end of the KFP test](https://github.com/canonical/charmed-kubeflow-uats/issues/23) | 0 |
-| tensorflow/probability | Jupyter Notebook | [Feature Request: Add crps method to tfp.distributions](https://github.com/tensorflow/probability/issues/1340) | 1 |
-| tensorflow/probability | Jupyter Notebook | [Keyword argument overload (?) in tfb.real_nvp_default_template](https://github.com/tensorflow/probability/issues/350) | 1 |
-| tensorflow/probability | Jupyter Notebook | [Item response theory model example/tutorial](https://github.com/tensorflow/probability/issues/69) | 1 |
-| tensorflow/probability | Jupyter Notebook | [Bayesian neural network tutorial](https://github.com/tensorflow/probability/issues/66) | 1 |
-| tensorflow/swift-models | Jupyter Notebook | [Add logging callbacks for training statistics ](https://github.com/tensorflow/swift-models/issues/663) | 1 |
-| canonical/charmed-kubeflow-uats | Jupyter Notebook | [Format and lint `ipynb` files with `black`](https://github.com/canonical/charmed-kubeflow-uats/issues/8) | 1 |
-| pytorch/functorch | Jupyter Notebook | [Add vmap support for PyTorch operators](https://github.com/pytorch/functorch/issues/1088) | 2 |
-| tensorflow/probability | Jupyter Notebook | [Support for SeparableConv1DFlipout](https://github.com/tensorflow/probability/issues/745) | 2 |
-| tensorflow/probability | Jupyter Notebook | [NotImplementedError: mean is not implemented: Categorical](https://github.com/tensorflow/probability/issues/685) | 2 |
-| tensorflow/probability | Jupyter Notebook | [Always-on dropout layer](https://github.com/tensorflow/probability/issues/420) | 2 |
-| tensorflow/probability | Jupyter Notebook | [DenseFlipOut layer](https://github.com/tensorflow/probability/issues/88) | 2 |
-| tensorflow/probability | Jupyter Notebook | [Categorical autoregressive distribution with LSTM example/tutorial](https://github.com/tensorflow/probability/issues/73) | 2 |
-| tensorflow/swift-models | Jupyter Notebook | [Better error message on unzip failure](https://github.com/tensorflow/swift-models/issues/675) | 2 |
-| tensorflow/swift-models | Jupyter Notebook | [Find a more descriptive word for `numericalized`](https://github.com/tensorflow/swift-models/issues/598) | 2 |
-| tensorflow/swift-models | Jupyter Notebook | [Rewrite long nested `Sequential` types using `Sequential{N}` typealiases](https://github.com/tensorflow/swift-models/issues/492) | 2 |
-| tensorflow/swift-models | Jupyter Notebook | [[BERT-CoLA] Data source resolution](https://github.com/tensorflow/swift-models/issues/488) | 2 |
-| tensorflow/swift-models | Jupyter Notebook | [Object detection examples](https://github.com/tensorflow/swift-models/issues/149) | 2 |
-| huggingface/optimum-intel | Jupyter Notebook | [Fix conversion of ltx_video models in bf16 format](https://github.com/huggingface/optimum-intel/issues/1614) | 2 |
-| tensorflow/adanet | Jupyter Notebook | [Allow one to forward features to predictions](https://github.com/tensorflow/adanet/issues/114) | 3 |
-| tensorflow/probability | Jupyter Notebook | [Feature Request: Alternative Horseshoe Parameterization as tfp distribution](https://github.com/tensorflow/probability/issues/1465) | 3 |
-| tensorflow/probability | Jupyter Notebook | [Please add example on NUTS sampling from posterior for Bayesian Logistic Regression](https://github.com/tensorflow/probability/issues/588) | 3 |
-| tensorflow/probability | Jupyter Notebook | [Feature request: Tweedie distribution](https://github.com/tensorflow/probability/issues/529) | 3 |
-| tensorflow/probability | Jupyter Notebook | [CholeskyWishart distribution](https://github.com/tensorflow/probability/issues/527) | 3 |
-| tensorflow/probability | Jupyter Notebook | [improve text and visuals in Bayesian Gaussian mixture model tutorial](https://github.com/tensorflow/probability/issues/74) | 3 |
-| tensorflow/swift | Jupyter Notebook | [Installation verification tool](https://github.com/tensorflow/swift/issues/479) | 3 |
-| tensorflow/probability | Jupyter Notebook | [A question about target_log_prob_fn](https://github.com/tensorflow/probability/issues/611) | 4 |
-| tensorflow/probability | Jupyter Notebook | [Provide a resimulation Metropolis TransitionKernel](https://github.com/tensorflow/probability/issues/218) | 4 |
-| tensorflow/swift-models | Jupyter Notebook | [Translation example](https://github.com/tensorflow/swift-models/issues/148) | 4 |
-| huggingface/optimum-intel | Jupyter Notebook | [Add tests which check, that required transformations are applied](https://github.com/huggingface/optimum-intel/issues/1645) | 4 |
-| tensorflow/probability | Jupyter Notebook | [Laplace approximation](https://github.com/tensorflow/probability/issues/570) | 5 |
-| tensorflow/probability | Jupyter Notebook | [Missing Inverse Wishart - redefine Wishart?](https://github.com/tensorflow/probability/issues/247) | 5 |
-| tensorflow/probability | Jupyter Notebook | [Categorical features in logistic regression](https://github.com/tensorflow/probability/issues/94) | 5 |
-| tensorflow/probability | Jupyter Notebook | [Stochastic block model example/tutorial](https://github.com/tensorflow/probability/issues/71) | 5 |
-| tensorflow/probability | Jupyter Notebook | [Tutorial on Variational Inference](https://github.com/tensorflow/probability/issues/149) | 6 |
-| tensorflow/probability | Jupyter Notebook | [BFGS user should be able to pass parameters to the line search](https://github.com/tensorflow/probability/issues/1043) | 7 |
-| tensorflow/swift-models | Jupyter Notebook | [Speech to text example](https://github.com/tensorflow/swift-models/issues/147) | 7 |
-| tensorflow/probability | Jupyter Notebook | [Any plans to update the examples to TensorFlow 2?](https://github.com/tensorflow/probability/issues/607) | 8 |
-| tensorflow/probability | Jupyter Notebook | [Sample different weights for examples within a  batch](https://github.com/tensorflow/probability/issues/153) | 9 |
-| tensorflow/probability | Jupyter Notebook | [[Feature Request] tensorflow_probability.distributions.GeneralizedGamma](https://github.com/tensorflow/probability/issues/1081) | 11 |
-| huggingface/huggingface-gemma-recipes | Jupyter Notebook | [📣 Call for contributions!](https://github.com/huggingface/huggingface-gemma-recipes/issues/4) | 11 |
-| tensorflow/probability | Jupyter Notebook | [Feature Request: Efficient Poisson Binomial PMF/CDF in tfp](https://github.com/tensorflow/probability/issues/1453) | 13 |
-| tensorflow/probability | Jupyter Notebook | [[Feature Request] Zero-Inflated Poisson and Negative Binomial distributions](https://github.com/tensorflow/probability/issues/1134) | 13 |
-| tensorflow/swift-models | Jupyter Notebook | [UNet Example](https://github.com/tensorflow/swift-models/issues/35) | 15 |
-| huggingface/huggingface-llama-recipes | Jupyter Notebook | [Call for contributions](https://github.com/huggingface/huggingface-llama-recipes/issues/43) | 20 |
-| huggingface/agents-course | MDX | [Improve diagrams in unit 2.1](https://github.com/huggingface/agents-course/issues/233) | 6 |
-| tensorflow/mlir | Other | [Implement support for qualified symbols](https://github.com/tensorflow/mlir/issues/186) | 0 |
-| huggingface/awesome-huggingface | Other | [[hacktoberfest] Hugging Face Collections Hacktoberfest challenge](https://github.com/huggingface/awesome-huggingface/issues/28) | 0 |
-| decentraland/dapps-issues | Other | [[Events] Update the Share link to use the new `jump-in` site.](https://github.com/decentraland/dapps-issues/issues/247) | 0 |
-| decentraland/dapps-issues | Other | [Add a banner to communicate possible downtimes of our/thirdparty services](https://github.com/decentraland/dapps-issues/issues/20) | 0 |
-| canonical/chisel-docs | Other | [FAQ content needs redistribution](https://github.com/canonical/chisel-docs/issues/39) | 0 |
-| canonical/chisel-releases | Other | [feat(iptables): improve `iptables` test coverage](https://github.com/canonical/chisel-releases/issues/997) | 0 |
-| canonical/chisel-releases | Other | [ci: bump `setup-lxd`](https://github.com/canonical/chisel-releases/issues/816) | 0 |
-| canonical/chisel-releases | Other | [ci: figure out which spread tests to run first](https://github.com/canonical/chisel-releases/issues/774) | 0 |
-| canonical/chisel-releases | Other | [ci: networking error preparing lxd in tests (2)](https://github.com/canonical/chisel-releases/issues/757) | 0 |
-| canonical/chisel-releases | Other | [Add `logrotate` slice](https://github.com/canonical/chisel-releases/issues/551) | 0 |
-| canonical/chisel-releases | Other | [Add `cron` slice](https://github.com/canonical/chisel-releases/issues/550) | 0 |
-| canonical/chisel-releases | Other | [Add `socat` slice](https://github.com/canonical/chisel-releases/issues/533) | 0 |
-| canonical/sphinx-stack | Other | [Replace value of ogp_image in conf.py to an image included in the repository instead of assets manager](https://github.com/canonical/sphinx-stack/issues/512) | 0 |
-| canonical/sphinx-stack | Other | [Housekeeping: update preview logo](https://github.com/canonical/sphinx-stack/issues/215) | 0 |
-| canonical/sphinx-stack-docs | Other | ["Style guide" documents are superfluous and should be syntax guides](https://github.com/canonical/sphinx-stack-docs/issues/7) | 0 |
-| decentraland/sdk | Other | [Remove the mandatory `?v=` from the renderer fetch](https://github.com/decentraland/sdk/issues/201) | 1 |
-| canonical/charmed-mysql-rock | Other | [Add tests](https://github.com/canonical/charmed-mysql-rock/issues/47) | 1 |
-| canonical/chisel-releases | Other | [feat(systemd): improve `systemd` test coverage](https://github.com/canonical/chisel-releases/issues/989) | 1 |
-| canonical/chisel-releases | Other | [ci: stale `test_install_slices`](https://github.com/canonical/chisel-releases/issues/718) | 1 |
-| canonical/chisel-releases | Other | [Add `adduser` slice](https://github.com/canonical/chisel-releases/issues/549) | 1 |
-| canonical/sphinx-stack | Other | [Underscores in anchor](https://github.com/canonical/sphinx-stack/issues/390) | 1 |
-| canonical/sphinx-stack | Other | [Make 'Sphinx python dependency build checks' optional](https://github.com/canonical/sphinx-stack/issues/332) | 1 |
-| canonical/chisel-docs | Other | [Replace images in docs/explanation/mode-of-operation.md](https://github.com/canonical/chisel-docs/issues/31) | 2 |
-| canonical/chisel-releases | Other | [feat(25.10): arch-dependent gcc slices](https://github.com/canonical/chisel-releases/pull/896) | 2 |
-| canonical/launchpad-manual | Other | [Missing page: list of tags for bug reports](https://github.com/canonical/launchpad-manual/issues/158) | 2 |
-| canonical/chisel-releases | Other | [feat(ci): pass `GITHUB_TOKEN` to the lxd spread machine](https://github.com/canonical/chisel-releases/issues/798) | 3 |
-| canonical/chisel-releases | Other | [Where can we get `hostname`, `perl`, `opt` and `awk` slices?](https://github.com/canonical/chisel-releases/issues/502) | 3 |
-| canonical/kernel-docs | Other | [Fix docs link comment and permissions in GHA workflow](https://github.com/canonical/kernel-docs/issues/83) | 3 |
-| tensorflow/mlir | Other | [Consider trip count in loop invariant code motion](https://github.com/tensorflow/mlir/issues/194) | 4 |
-| canonical/chisel-releases | Other | [Add `drill` / `ldnsutils`](https://github.com/canonical/chisel-releases/issues/554) | 4 |
-| canonical/kernel-docs | Other | [Add recommended next steps for How to build a Linux kernel](https://github.com/canonical/kernel-docs/issues/10) | 4 |
-| canonical/chisel-releases | Other | [Please split common converters slice from libc6 gconv slice ](https://github.com/canonical/chisel-releases/issues/368) | 5 |
-| canonical/kernel-docs | Other | [Glossary - LRM](https://github.com/canonical/kernel-docs/issues/9) | 6 |
-| tensorflow/mlir | Other | [[LLVM] Implement missing LLVM IR instructions](https://github.com/tensorflow/mlir/issues/276) | 11 |
-| zeromicro/goctl-swagger | PHP | [support for openapi 3.0 ](https://github.com/zeromicro/goctl-swagger/issues/52) | 0 |
-| godotengine/godot-asset-library | PHP | [Categories need a description (tooltip?) when hovered/selected](https://github.com/godotengine/godot-asset-library/issues/74) | 1 |
-| godotengine/godot-asset-library | PHP | [keep the content of the submition form when its not validated, or try some ajax realtime pre-validation](https://github.com/godotengine/godot-asset-library/issues/61) | 1 |
-| godotengine/godot-asset-library | PHP | [A way to cancel edit requests](https://github.com/godotengine/godot-asset-library/issues/149) | 3 |
-| godotengine/godot-asset-library | PHP | [Sanitize inputs for Asset data/fields, like URLs](https://github.com/godotengine/godot-asset-library/issues/204) | 5 |
+| pytorch/ao | Python | [Resolve doc build warnings](https://github.com/pytorch/ao/issues/3863) | 2 |
+| pytorch/ao | Python | [Update documents addressing AQT workflow](https://github.com/pytorch/ao/issues/3637) | 12 |
+| pytorch/ao | Python | [FP8 Blockwise Training Tracker](https://github.com/pytorch/ao/issues/3290) | 3 |
 | pytorch/ao | Python | [TorchAO ROCM tests are taking a long time](https://github.com/pytorch/ao/issues/2367) | 0 |
+| pytorch/ao | Python | [Refactor torchao and tests to use model architectures from torchao.testing.model_architectures](https://github.com/pytorch/ao/issues/2078) | 2 |
+| pytorch/ao | Python | [Accelerate activation sparsity with activation compression](https://github.com/pytorch/ao/issues/1920) | 6 |
+| pytorch/ao | Python | [Unittests Migration Progress](https://github.com/pytorch/ao/issues/1621) | 2 |
+| pytorch/ao | Python | [[QAT] Low-bit FSDP all-gather for QAT](https://github.com/pytorch/ao/issues/1224) | 3 |
+| pytorch/ao | Python | [Add codebook (look up table based) quantization flow in torchao](https://github.com/pytorch/ao/issues/1195) | 18 |
+| pytorch/ao | Python | [[low-bit optim] Add COAT optimizer](https://github.com/pytorch/ao/issues/1190) | 5 |
+| pytorch/ao | Python | [[sparse] Add GPTQ support for sparse-marlin](https://github.com/pytorch/ao/issues/1134) | 3 |
+| pytorch/ao | Python | [Named Symbol not found (torchchat #1298)](https://github.com/pytorch/ao/issues/1110) | 11 |
+| pytorch/ao | Python | [[MX | Triton] Create MX matmul op using new `scaled_dot` op in Triton](https://github.com/pytorch/ao/issues/1084) | 2 |
+| pytorch/ao | Python | [Support for GrokAdamW](https://github.com/pytorch/ao/issues/1032) | 2 |
+| pytorch/ao | Python | [Add weight tensor-wise scaling for INT8 quantized and mixed-precision training](https://github.com/pytorch/ao/issues/1010) | 1 |
+| pytorch/ao | Python | [Tensor Parallelism Support for AffineQuantizedTensor](https://github.com/pytorch/ao/issues/988) | 3 |
+| pytorch/ao | Python | [[MPS] torchao low-bit-precision optim does not expose 'backend' argument to torch.compile](https://github.com/pytorch/ao/issues/955) | 11 |
+| pytorch/ao | Python | [MoE example ](https://github.com/pytorch/ao/issues/729) | 1 |
+| pytorch/ao | Python | [Tensor subclass boilerplate can be consolidated](https://github.com/pytorch/ao/issues/710) | 2 |
+| pytorch/ao | Python | [Self compressing neural networks](https://github.com/pytorch/ao/issues/658) | 1 |
+| pytorch/ao | Python | [Replace flash_4 with FlexAttention](https://github.com/pytorch/ao/issues/639) | 17 |
+| pytorch/ao | Python | [[llama] Use horizontal fusion trick from Attention for FeedForward](https://github.com/pytorch/ao/issues/606) | 4 |
+| pytorch/ao | Python | [Quantized Training](https://github.com/pytorch/ao/issues/554) | 4 |
+| pytorch/ao | Python | [[RFC] Intx Tensor Subclasses Quantization](https://github.com/pytorch/ao/issues/439) | 2 |
+| pytorch/ao | Python | [The next tutorials](https://github.com/pytorch/ao/issues/426) | 5 |
+| pytorch/audio | Python | [Use non-persistent buffers](https://github.com/pytorch/audio/issues/3059) | 9 |
+| pytorch/audio | Python | [read mp3 file fail](https://github.com/pytorch/audio/issues/2867) | 5 |
+| pytorch/audio | Python | [Add Stereo to Mono Convertions](https://github.com/pytorch/audio/issues/877) | 18 |
+| pytorch/ci-hud | JavaScript | [Restore "Show service jobs" checkbox to GitHubStatusDisplay.js ](https://github.com/pytorch/ci-hud/issues/110) | 2 |
+| pytorch/examples | Python | [word_language_model with torch.nn.modules.transformer](https://github.com/pytorch/examples/issues/1112) | 3 |
+| pytorch/examples | Python | [Update all examples to latest versions of pytorch](https://github.com/pytorch/examples/issues/976) | 2 |
+| pytorch/examples | Python | [Warning: an output with one or more elements was resized since it had shape[xxxx],]](https://github.com/pytorch/examples/issues/937) | 2 |
+| pytorch/examples | Python | [Video classification example](https://github.com/pytorch/examples/issues/895) | 1 |
+| pytorch/examples | Python | [OSError: [Errno 22] Invalid argument:](https://github.com/pytorch/examples/issues/887) | 3 |
+| pytorch/examples | Python | [Please change dcgan to load truncated images.](https://github.com/pytorch/examples/issues/835) | 4 |
+| pytorch/examples | Python | [Resume will override learning rate on command line.](https://github.com/pytorch/examples/issues/816) | 1 |
+| pytorch/examples | Python | [Add nn.SyncBatchNorm in ImageNet example](https://github.com/pytorch/examples/issues/793) | 2 |
+| pytorch/examples | Python | [MNIST test_loader not being used as intended (wrong)!](https://github.com/pytorch/examples/issues/756) | 3 |
+| pytorch/examples | Python | [Actor critic example not using discount rate properly](https://github.com/pytorch/examples/issues/744) | 3 |
 | pytorch/examples | Python | [imagenet benchmark measure elapsed time function issue](https://github.com/pytorch/examples/issues/741) | 0 |
+| pytorch/examples | Python | [No matching function call  error in custom_dataset example ](https://github.com/pytorch/examples/issues/680) | 4 |
+| pytorch/examples | Python | [Add Siamese Network example](https://github.com/pytorch/examples/issues/645) | 4 |
+| pytorch/examples | Python | [mnist example contains bad practices leading to wrongful results](https://github.com/pytorch/examples/issues/623) | 2 |
+| pytorch/examples | Python | [Input type and weight type should be the same](https://github.com/pytorch/examples/issues/599) | 2 |
+| pytorch/examples | Python | [A question about weight initialization of embedding layer.](https://github.com/pytorch/examples/issues/595) | 1 |
 | pytorch/examples | Python | [Why there is no tanh activation at the end of TransformerNet?](https://github.com/pytorch/examples/issues/570) | 0 |
+| pytorch/examples | Python | [please use longer names for variables than 2-3 letter acronyms](https://github.com/pytorch/examples/issues/487) | 2 |
+| pytorch/examples | Python | [Changes needed to run DCGAN 32x32 ](https://github.com/pytorch/examples/issues/486) | 1 |
+| pytorch/examples | Python | [VAE reconstruction loss (BCE) ](https://github.com/pytorch/examples/issues/460) | 2 |
 | pytorch/examples | Python | [Distributed doesn't work with env:// init_method](https://github.com/pytorch/examples/issues/458) | 0 |
 | pytorch/examples | Python | [Is the loss of the first word covered during the language model evaluation?](https://github.com/pytorch/examples/issues/453) | 0 |
 | pytorch/examples | Python | [The casting problem on the result of the model.](https://github.com/pytorch/examples/issues/433) | 0 |
+| pytorch/examples | Python | [ImageFolder doc should clarify 1. order that images returned in 2. that all classes are concatenated into a single list](https://github.com/pytorch/examples/issues/400) | 1 |
+| pytorch/examples | Python | [Why don't we use MSE as a reconstruction loss for VAE ?](https://github.com/pytorch/examples/issues/399) | 7 |
 | pytorch/examples | Python | [Example code (mnist) does not work under torch.utils.bottleneck](https://github.com/pytorch/examples/issues/391) | 0 |
+| pytorch/examples | Python | [Imagenet training extremely low gpu utilization](https://github.com/pytorch/examples/issues/387) | 2 |
+| pytorch/examples | Python | ["omit freeze_support"](https://github.com/pytorch/examples/issues/323) | 3 |
+| pytorch/examples | Python | [Doc comment on `accuracy` method in imagenet example, incorrect?](https://github.com/pytorch/examples/issues/312) | 1 |
+| pytorch/examples | Python | [Ambiguous code in reinforce](https://github.com/pytorch/examples/issues/297) | 2 |
+| pytorch/executorch | Python | [Good First Issue: Enable Gemma 4 on MLX Backend](https://github.com/pytorch/executorch/issues/18928) | 5 |
+| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.bitwise_xor`](https://github.com/pytorch/executorch/issues/18927) | 5 |
 | pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.bitwise_or`](https://github.com/pytorch/executorch/issues/18926) | 0 |
+| pytorch/executorch | Python | [Good First Issue: Add Full Integer Support for `aten.bitwise_and`](https://github.com/pytorch/executorch/issues/18925) | 2 |
+| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.trunc`](https://github.com/pytorch/executorch/issues/18923) | 2 |
+| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.isinf`](https://github.com/pytorch/executorch/issues/18922) | 1 |
 | pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.hardtanh`](https://github.com/pytorch/executorch/issues/18921) | 0 |
+| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for aten.flip](https://github.com/pytorch/executorch/issues/18918) | 1 |
+| pytorch/executorch | Python | [[Arm] Size-test: Run the binary on CI](https://github.com/pytorch/executorch/issues/12812) | 2 |
+| pytorch/executorch | Python | [Consolidation of Selective Build APIs for OSS](https://github.com/pytorch/executorch/issues/11921) | 2 |
+| pytorch/executorch | Python | [Rename `executorch` cmake target to `prim_ops_lib`](https://github.com/pytorch/executorch/issues/11761) | 7 |
+| pytorch/executorch | Python | [torch.split fails in to_edge](https://github.com/pytorch/executorch/issues/11723) | 3 |
+| pytorch/executorch | Python | [Support dim order in Java Tensor](https://github.com/pytorch/executorch/issues/11593) | 2 |
+| pytorch/executorch | Python | [Support Standalone Batch Norm](https://github.com/pytorch/executorch/issues/11586) | 3 |
+| pytorch/executorch | Python | [Add dynamism tests for xnnpack model tests](https://github.com/pytorch/executorch/issues/11585) | 1 |
+| pytorch/executorch | Python | [Implement load_into for the shared_ptr data loader](https://github.com/pytorch/executorch/issues/11562) | 1 |
+| pytorch/executorch | Python | [Manual kernel registration to include library names in API](https://github.com/pytorch/executorch/issues/11221) | 6 |
+| pytorch/executorch | Python | [Re-inplace slice_copy with slice](https://github.com/pytorch/executorch/issues/10917) | 4 |
+| pytorch/executorch | Python | [[Android] Rename JNI cpp file](https://github.com/pytorch/executorch/issues/10890) | 3 |
+| pytorch/executorch | Python | [Get rid of fixed number cmake --build -j in sh and docs](https://github.com/pytorch/executorch/issues/10887) | 3 |
+| pytorch/executorch | Python | [Consolidate executor_runners](https://github.com/pytorch/executorch/issues/10819) | 3 |
+| pytorch/executorch | Python | [Add timestamps for pte generation in CI](https://github.com/pytorch/executorch/issues/10761) | 7 |
+| pytorch/executorch | Python | [Add torchao kernels to xcframework](https://github.com/pytorch/executorch/issues/10694) | 2 |
 | pytorch/executorch | Python | [[CMake] Potentially duplicated srcs in llama_runner build](https://github.com/pytorch/executorch/issues/10686) | 0 |
+| pytorch/executorch | Python | [Need a feature to get etdump while running LLAMA model on qnn with qnn_llama_runner](https://github.com/pytorch/executorch/issues/10580) | 2 |
+| pytorch/executorch | Python | [[Android] Use generic JNI instead of fbjni](https://github.com/pytorch/executorch/issues/10444) | 1 |
+| pytorch/executorch | Python | [[Request impl] Gracefully error out in ETDump](https://github.com/pytorch/executorch/issues/9971) | 2 |
+| pytorch/executorch | Python | [Check tensor's dim order ambiguity in IR verifier](https://github.com/pytorch/executorch/issues/9942) | 10 |
+| pytorch/executorch | Python | [[Request impl] Devtool end-to-end tests](https://github.com/pytorch/executorch/issues/9778) | 18 |
+| pytorch/executorch | Python | [[Request Impl] Apply Segment Serialization in Bundled Program](https://github.com/pytorch/executorch/issues/9771) | 7 |
+| pytorch/functorch | Jupyter Notebook | [Add vmap support for PyTorch operators](https://github.com/pytorch/functorch/issues/1088) | 2 |
+| pytorch/glow | C++ | [Use explicit std::string conversions instead of implicit llvm::StringRef->std::string conversions to prepare Glow for builds using LLVM >=11](https://github.com/pytorch/glow/issues/5068) | 18 |
+| pytorch/glow | C++ | [Fuse RescaleQuantized in the ChannelwiseQuantizedConv](https://github.com/pytorch/glow/issues/4928) | 5 |
+| pytorch/glow | C++ | [[CPU] Remove the need for Rescale for the CPUMaxSplat](https://github.com/pytorch/glow/issues/4656) | 1 |
+| pytorch/glow | C++ | [New files added under glow/test/models/ don't get copied to build folder until clean build is performed.](https://github.com/pytorch/glow/issues/4647) | 2 |
+| pytorch/glow | C++ | [[GraphOptz] Sink Quantize below Reshape](https://github.com/pytorch/glow/issues/4629) | 4 |
+| pytorch/glow | C++ | [[ONNXModelLoader] Support for LogSoftmax operator is missing](https://github.com/pytorch/glow/issues/4399) | 16 |
+| pytorch/glow | C++ | [[TensorLayout] Add a way to specify canonical layout propagation to NodeGen](https://github.com/pytorch/glow/issues/3834) | 0 |
+| pytorch/glow | C++ | [Move layout information from nodes constructor' to their Glow types](https://github.com/pytorch/glow/issues/3790) | 3 |
+| pytorch/glow | C++ | [[habana] Implement backend specific verifications](https://github.com/pytorch/glow/issues/3480) | 3 |
+| pytorch/glow | C++ | [Bring back the sinking RELU below Pool optimization](https://github.com/pytorch/glow/issues/3247) | 5 |
+| pytorch/glow | C++ | [[Runtime] Expand Yaml DeviceConfig loading to include HostConfig](https://github.com/pytorch/glow/issues/3079) | 0 |
+| pytorch/glow | C++ | [[runtime] add device memory size configuration to the DeviceConfig::parameters map on all backends](https://github.com/pytorch/glow/issues/2899) | 0 |
+| pytorch/glow | C++ | [resnet-* example code should reuse Tensor memory for images](https://github.com/pytorch/glow/issues/2898) | 0 |
+| pytorch/glow | C++ | [Make all useful data structures in Glow easy to dump in a textual form](https://github.com/pytorch/glow/issues/2831) | 2 |
+| pytorch/glow | C++ | [Example binaries should handle HostManager active request limit](https://github.com/pytorch/glow/issues/2816) | 0 |
+| pytorch/glow | C++ | [Use gtest-parallel](https://github.com/pytorch/glow/issues/2412) | 5 |
+| pytorch/glow | C++ | [[ONNXIFI] Add additional precondition checks to model loaders](https://github.com/pytorch/glow/issues/2188) | 0 |
+| pytorch/glow | C++ | [[ONNXIFI][GraphAPI] Add "orErr" methods for graph creation api](https://github.com/pytorch/glow/issues/2187) | 0 |
+| pytorch/glow | C++ | [Make the execution of the Glow compiler more deterministic between multiple runs](https://github.com/pytorch/glow/issues/1948) | 9 |
+| pytorch/glow | C++ | [[Importers] Move "run and compare" tests from importer tests to operator tests](https://github.com/pytorch/glow/issues/1909) | 2 |
+| pytorch/glow | C++ | [ConvBench should use the layers of ResNet](https://github.com/pytorch/glow/issues/1887) | 0 |
+| pytorch/glow | C++ | [ConvBench should use libjit_convolution_D8KKC8](https://github.com/pytorch/glow/issues/1886) | 0 |
+| pytorch/glow | C++ | [Glow should provide its own implementation of a random number generator to ensure deterministic testing and avoid platform-dependent differences](https://github.com/pytorch/glow/issues/1556) | 6 |
+| pytorch/glow | C++ | [Need to canonicalize or optimize high-dim concat to concat+transpose](https://github.com/pytorch/glow/issues/1296) | 2 |
+| pytorch/ignite | Python | [Updating getting started to add code for the setup_tb_logger](https://github.com/pytorch/ignite/issues/3735) | 6 |
+| pytorch/ignite | Python | [🥇 Everyone is welcome to contribute 💯 ](https://github.com/pytorch/ignite/issues/2026) | 40 |
 | pytorch/PiPPy | Python | [Support Segformer models in HF tests](https://github.com/pytorch/PiPPy/issues/592) | 0 |
 | pytorch/PiPPy | Python | [Support ConvNext models in HF tests](https://github.com/pytorch/PiPPy/issues/486) | 0 |
 | pytorch/PiPPy | Python | [Support Wav2Vec2 models in HF tests](https://github.com/pytorch/PiPPy/issues/485) | 0 |
@@ -297,431 +162,359 @@ If you are wondering where to begin in the  journey contributing to open-source 
 | pytorch/PiPPy | Python | [Support LxmertForPreTraining models in HF tests](https://github.com/pytorch/PiPPy/issues/253) | 0 |
 | pytorch/PiPPy | Python | [Support Speech2Text models in HF tests](https://github.com/pytorch/PiPPy/issues/249) | 0 |
 | pytorch/PiPPy | Python | [Support CLIP models in HF tests](https://github.com/pytorch/PiPPy/issues/248) | 0 |
+| pytorch/PiPPy | Python | [Support LayoutLM models in HF tests](https://github.com/pytorch/PiPPy/issues/247) | 1 |
 | pytorch/PiPPy | Python | [Support SWIN models in HF tests](https://github.com/pytorch/PiPPy/issues/243) | 0 |
+| pytorch/PiPPy | Python | [Make RemoteInterpreter use the full implementation of `Interpreter.run`](https://github.com/pytorch/PiPPy/issues/25) | 2 |
+| pytorch/probot | TypeScript | [deprecation of `number` for octokit](https://github.com/pytorch/probot/issues/62) | 1 |
+| pytorch/pytorch | Python | [[Docathon] Convert `nn.init.rst` from rST to MyST Markdown](https://github.com/pytorch/pytorch/issues/182479) | 3 |
+| pytorch/pytorch | Python | [[Docathon] Convert `elastic/run.rst` from rST to MyST Markdown](https://github.com/pytorch/pytorch/issues/182472) | 5 |
+| pytorch/pytorch | Python | [Use typing_extensions.TypeAliasType for better reexport of `__module__`](https://github.com/pytorch/pytorch/issues/171905) | 5 |
+| pytorch/pytorch | Python | [torch.compile regression 2.9.1: Triton kernel name '_Runner__kernel_name_0' is not defined](https://github.com/pytorch/pytorch/issues/170398) | 13 |
+| pytorch/pytorch | Python | [[auto functionalize][partitioner] ones_like is not getting recomputed](https://github.com/pytorch/pytorch/issues/170160) | 3 |
+| pytorch/pytorch | Python | [[dynamo] [dynamic] `torch.combinations` throws RuntimeError when `(backend=aot_eager, dynamic=True)`](https://github.com/pytorch/pytorch/issues/163759) | 12 |
+| pytorch/pytorch | Python | [foreach_map enhancements](https://github.com/pytorch/pytorch/issues/158968) | 11 |
+| pytorch/pytorch | Python | [Make tlparse able to show a summary of distinct graph breaks](https://github.com/pytorch/pytorch/issues/153669) | 14 |
+| pytorch/pytorch | Python | [[Feature request] `torch.export` .save/.load could support `safetensors` and/or `weights_only=True`](https://github.com/pytorch/pytorch/issues/153410) | 13 |
+| pytorch/pytorch | Python | [[BUG][PyTorch 2.0 Export][quant]:get_source_partitions() may return different matches with same input graph](https://github.com/pytorch/pytorch/issues/147170) | 8 |
+| pytorch/pytorch | Python | [Improve error message for wrong number of arguments in CachingAutotuner](https://github.com/pytorch/pytorch/issues/146018) | 9 |
+| pytorch/pytorch | Python | [Report WHY a symbol was created dynamically in symbolic_shapes logs](https://github.com/pytorch/pytorch/issues/137527) | 5 |
+| pytorch/pytorch | Python | [Docs are little bit outdated for torch logs](https://github.com/pytorch/pytorch/issues/137285) | 11 |
+| pytorch/pytorch | Python | [bmm, topk, cholesky, linalg.norm, max with out variants set causing recompilations in torch.compile](https://github.com/pytorch/pytorch/issues/135859) | 11 |
+| pytorch/pytorch | Python | [dynamo (re)compilation issues: shape (1,1), nn.Parameter, mark_dynamic](https://github.com/pytorch/pytorch/issues/135011) | 9 |
+| pytorch/pytorch | Python | [[BE] Deduplicate auto_functionalized and triton_kernel_wrapper_functional](https://github.com/pytorch/pytorch/issues/133443) | 2 |
+| pytorch/pytorch | Python | [[export] Schematize nn_module_stack serialization](https://github.com/pytorch/pytorch/issues/131941) | 4 |
+| pytorch/pytorch | Python | [torch.fx.Tracer.record_stack_traces is broken in torch 2.4.0](https://github.com/pytorch/pytorch/issues/130861) | 5 |
+| pytorch/pytorch | Python | [Expand Tag Set: views & reductions](https://github.com/pytorch/pytorch/issues/129020) | 10 |
+| pytorch/pytorch | Python | [[Dynamo] Support tracing through _get_current_dispatch_mode_stack](https://github.com/pytorch/pytorch/issues/125694) | 9 |
+| pytorch/pytorch | Python | [Obscure error: Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_list'](https://github.com/pytorch/pytorch/issues/122129) | 18 |
+| pytorch/pytorch | Python | [AOTAutograd: functionalization should emit foreach_copy_() instead of copy_() when possible](https://github.com/pytorch/pytorch/issues/119191) | 6 |
+| pytorch/pytorch | Python | [Supporting custom attributes with `__torch_function__` tensor subclasses](https://github.com/pytorch/pytorch/issues/117806) | 17 |
+| pytorch/pytorch | Python | [Logging when executing fx.Interpreter](https://github.com/pytorch/pytorch/issues/117351) | 12 |
+| pytorch/pytorch | Python | [[dynamo] Missing support for many trivial builtin functions in operator](https://github.com/pytorch/pytorch/issues/116396) | 6 |
+| pytorch/pytorch | Python | [Enable ruff rule PLW1510 codebase wide](https://github.com/pytorch/pytorch/issues/115016) | 6 |
+| pytorch/pytorch | Python | [refactor TracingContext to take a more limited subset of ViewAndMutationMeta](https://github.com/pytorch/pytorch/issues/114403) | 5 |
+| pytorch/pytorch | Python | [[PT2] [Hardening] Track recompiles alongside graph breaks in our actual/expected comparison CI runs](https://github.com/pytorch/pytorch/issues/113040) | 2 |
+| pytorch/pytorch | Python | [Enable more flake8-pyi ruff checks](https://github.com/pytorch/pytorch/issues/110950) | 7 |
+| pytorch/pytorch | Python | [switch more test cases to use MultithreadTestCase](https://github.com/pytorch/pytorch/issues/108744) | 4 |
+| pytorch/rl | Python | [[Feature Request] Missing ActionScaling and FlattenAction ](https://github.com/pytorch/rl/issues/1209) | 5 |
+| pytorch/rl | Python | [[Feature Request] Make sure that all losses work with tensorclasses and regular tensors](https://github.com/pytorch/rl/issues/1062) | 2 |
+| pytorch/rl | Python | [[Feature Request] TensorSpec is_in methods should check the dtype of val](https://github.com/pytorch/rl/issues/793) | 2 |
+| pytorch/serve | Java | [Torchserve M1 support detailed plan](https://github.com/pytorch/serve/issues/2555) | 4 |
+| pytorch/serve | Java | [Handle invalid input intelligently ！](https://github.com/pytorch/serve/issues/2459) | 7 |
+| pytorch/serve | Java | [how does `default_response_timeout` work?](https://github.com/pytorch/serve/issues/2452) | 6 |
+| pytorch/serve | Java | [add support for SeTFiT models](https://github.com/pytorch/serve/issues/2107) | 4 |
+| pytorch/serve | Java | [permission error while trying to remove previous artifact files in `/tmp/`](https://github.com/pytorch/serve/issues/1532) | 3 |
+| pytorch/serve | Java | [[Educational] Typing `.py` files iteratively with mypy](https://github.com/pytorch/serve/issues/1512) | 1 |
+| pytorch/serve | Java | [The captum for bert notebook needs update](https://github.com/pytorch/serve/issues/1317) | 0 |
+| pytorch/serve | Java | [Built-in handler for regression](https://github.com/pytorch/serve/issues/987) | 1 |
+| pytorch/serve | Java | [Enable naked DIR test case for windows environment](https://github.com/pytorch/serve/issues/882) | 0 |
+| pytorch/serve | Java | [[BUG] Dockerfile with nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 gives ascii codec error](https://github.com/pytorch/serve/issues/821) | 4 |
+| pytorch/serve | Java | [[Suggestion] Loading torch-model-archiver arguments from YAML](https://github.com/pytorch/serve/issues/780) | 6 |
 | pytorch/tensordict | Python | [[Feature Request] Deprecate `_run_checks` in favour of `TensorDict._checked`](https://github.com/pytorch/tensordict/issues/182) | 0 |
+| pytorch/test-infra | TypeScript | [Mergebot merged a PR even though a review had been re-requested](https://github.com/pytorch/test-infra/issues/5543) | 5 |
+| pytorch/test-infra | TypeScript | [Better highlight scheme for force merges](https://github.com/pytorch/test-infra/issues/5229) | 0 |
+| pytorch/test-infra | TypeScript | [A better HUD menu for PyTorch repos family](https://github.com/pytorch/test-infra/issues/5226) | 4 |
+| pytorch/text | Python | [torchtext main branch doesn't support pytorch2.0](https://github.com/pytorch/text/issues/2052) | 1 |
+| pytorch/text | Python | [Convert iterator-style raw datasets to map-style raw datasets](https://github.com/pytorch/text/issues/1296) | 2 |
 | pytorch/torcharrow | Python | [Making BaseColumn::genericUnaryUDF and the family free functions](https://github.com/pytorch/torcharrow/issues/197) | 0 |
 | pytorch/torcharrow | Python | [Call type inferring in interop.from_pylist](https://github.com/pytorch/torcharrow/issues/80) | 0 |
+| pytorch/torcharrow | Python | [Default aggregation functions delegates to Arrow Compute ](https://github.com/pytorch/torcharrow/issues/53) | 1 |
 | pytorch/torcharrow | Python | [Move `torcharrow/test` to `test`](https://github.com/pytorch/torcharrow/issues/24) | 0 |
+| pytorch/torchchat | Python | [Improve Tokenizer New Type Onboarding](https://github.com/pytorch/torchchat/issues/1536) | 3 |
+| pytorch/torchchat | Python | [torchtune as an optional dependency: Lazy Import](https://github.com/pytorch/torchchat/issues/1519) | 2 |
+| pytorch/torchchat | Python | [GeneratorArgs.is_torchtune_model is a misnomer](https://github.com/pytorch/torchchat/issues/1273) | 1 |
+| pytorch/torchchat | Python | [Slimming down torchchat: Replace replace_attention_with_custom_sdpa_attention() with ET's implementation](https://github.com/pytorch/torchchat/issues/1058) | 2 |
+| pytorch/torchchat | Python | [[UX] We are too quiet about errors - in particular missing HF authentication...](https://github.com/pytorch/torchchat/issues/782) | 3 |
+| pytorch/torchdistx | Python | [Documentation for AnyPrecisionOptimizer](https://github.com/pytorch/torchdistx/issues/61) | 3 |
+| pytorch/torchtitan | Python | [Ability to train based on epoch](https://github.com/pytorch/torchtitan/issues/613) | 1 |
+| pytorch/xla | C++ | [xs.make_mesh](https://github.com/pytorch/xla/issues/8838) | 1 |
+| pytorch/xla | C++ | [torch_xla scan forces inputs to be differentiable](https://github.com/pytorch/xla/issues/8783) | 1 |
+| pytorch/xla | C++ | [[torch_xla] scan_layers fails if the layer have no weights](https://github.com/pytorch/xla/issues/8748) | 1 |
+| pytorch/xla | C++ | [[hard] Op info test for `special.airy_ai`](https://github.com/pytorch/xla/issues/7926) | 1 |
+| pytorch/xla | C++ | [Op info test for `bmm .. ceil`](https://github.com/pytorch/xla/issues/7546) | 0 |
+| pytorch/xla | C++ | [Op info test for `triangular_solve .. unfold`](https://github.com/pytorch/xla/issues/7541) | 1 |
+| pytorch/xla | C++ | [Op info test for `special.scaled_modified_bessel_k0 .. squeeze`](https://github.com/pytorch/xla/issues/7538) | 2 |
+| pytorch/xla | C++ | [Op info test for `rsub .. searchsorted`](https://github.com/pytorch/xla/issues/7532) | 0 |
+| pytorch/xla | C++ | [Op info test for `pinverse .. put`](https://github.com/pytorch/xla/issues/7529) | 4 |
+| pytorch/xla | C++ | [Op info test for `norm .. pca_lowrank`](https://github.com/pytorch/xla/issues/7528) | 0 |
+| pytorch/xla | C++ | [Op info test for `nn.functional.softmin .. nonzero_static`](https://github.com/pytorch/xla/issues/7527) | 0 |
+| pytorch/xla | C++ | [Op info test for `nn.functional.pixel_shuffle .. nn.functional.scaled_dot_product_attention`](https://github.com/pytorch/xla/issues/7526) | 1 |
+| pytorch/xla | C++ | [Op info test for `nn.functional.leaky_relu .. nn.functional.max_pool1d`](https://github.com/pytorch/xla/issues/7523) | 3 |
+| pytorch/xla | C++ | [Op info test for `nn.functional.group_norm .. nn.functional.layer_norm`](https://github.com/pytorch/xla/issues/7522) | 0 |
+| pytorch/xla | C++ | [Op info test for `nn.functional.feature_alpha_dropout .. nn.functional.grid_sample`](https://github.com/pytorch/xla/issues/7521) | 2 |
+| pytorch/xla | C++ | [Op info test for `nn.functional.conv_transpose3d .. nn.functional.ctc_loss`](https://github.com/pytorch/xla/issues/7519) | 0 |
+| pytorch/xla | C++ | [Op info test for `nn.functional.avg_pool1d .. nn.functional.bilinear`](https://github.com/pytorch/xla/issues/7517) | 4 |
+| pytorch/xla | C++ | [Op info test for `linalg.matrix_power`](https://github.com/pytorch/xla/issues/7495) | 2 |
+| pytorch/xla | C++ | [Op info test for `linalg.matrix_norm`](https://github.com/pytorch/xla/issues/7494) | 1 |
+| pytorch/xla | C++ | [Op info test for `linalg.lu_solve`](https://github.com/pytorch/xla/issues/7493) | 4 |
+| pytorch/xla | C++ | [Op info test for `linalg.lu_factor_ex`](https://github.com/pytorch/xla/issues/7492) | 1 |
+| pytorch/xla | C++ | [Op info test for `linalg.lu_factor`](https://github.com/pytorch/xla/issues/7491) | 1 |
+| pytorch/xla | C++ | [Op info test for `linalg.ldl_solve`](https://github.com/pytorch/xla/issues/7488) | 2 |
+| pytorch/xla | C++ | [Op info test for `linalg.ldl_factor_ex`](https://github.com/pytorch/xla/issues/7487) | 0 |
+| pytorch/xla | C++ | [Op info test for `linalg.householder_product`](https://github.com/pytorch/xla/issues/7483) | 0 |
+| pytorch/xla | C++ | [Op info test for `linalg.cholesky_ex`](https://github.com/pytorch/xla/issues/7463) | 0 |
+| pytorch/xla | C++ | [Op info test for `linalg.cholesky`](https://github.com/pytorch/xla/issues/7462) | 0 |
+| pytorch/xla | C++ | [Op info test for `kthvalue`](https://github.com/pytorch/xla/issues/7458) | 3 |
+| pytorch/xla | C++ | [Op info test for `index_reduce`](https://github.com/pytorch/xla/issues/7453) | 1 |
+| pytorch/xla | C++ | [[hard] Op info test for `histogramdd`](https://github.com/pytorch/xla/issues/7445) | 1 |
+| tensorflow/adanet | Jupyter Notebook | [Allow one to forward features to predictions](https://github.com/tensorflow/adanet/issues/114) | 3 |
+| tensorflow/addons | Python | [Benchmark test for rrelu fails on windows](https://github.com/tensorflow/addons/issues/839) | 3 |
+| tensorflow/agents | Python | [Tutorial 1: Train a Deep Q Network with TF-Agents and the use of a driver](https://github.com/tensorflow/agents/issues/554) | 1 |
+| tensorflow/graphics | Python | [Add skew to projective camera](https://github.com/tensorflow/graphics/issues/335) | 3 |
+| tensorflow/graphics | Python | [Tangential camera distortion/undistortion](https://github.com/tensorflow/graphics/issues/334) | 2 |
+| tensorflow/graphics | Python | [Add ScanNet dataset](https://github.com/tensorflow/graphics/issues/307) | 4 |
+| tensorflow/graphics | Python | [Not detecting TF Nightly when installing from whl.](https://github.com/tensorflow/graphics/issues/305) | 5 |
+| tensorflow/minigo | C++ | [Support more GTP commands](https://github.com/tensorflow/minigo/issues/46) | 3 |
+| tensorflow/mlir | Other | [[LLVM] Implement missing LLVM IR instructions](https://github.com/tensorflow/mlir/issues/276) | 11 |
+| tensorflow/mlir | Other | [Consider trip count in loop invariant code motion](https://github.com/tensorflow/mlir/issues/194) | 4 |
+| tensorflow/mlir | Other | [Implement support for qualified symbols](https://github.com/tensorflow/mlir/issues/186) | 0 |
+| tensorflow/model-card-toolkit | Python | [Prefer single quote strings model-card-toolkit](https://github.com/tensorflow/model-card-toolkit/issues/279) | 3 |
 | tensorflow/moonlight | Python | [Follow the MusicXML schema](https://github.com/tensorflow/moonlight/issues/65) | 0 |
 | tensorflow/moonlight | Python | [Export stem directions in MusicXML](https://github.com/tensorflow/moonlight/issues/25) | 0 |
 | tensorflow/moonlight | Python | [Chord duration correction](https://github.com/tensorflow/moonlight/issues/2) | 0 |
 | tensorflow/moonlight | Python | [Export the key signature to MusicXML](https://github.com/tensorflow/moonlight/issues/1) | 0 |
-| huggingface/lighteval | Python | [[BUG]  Optimize tokenization](https://github.com/huggingface/lighteval/issues/732) | 0 |
-| huggingface/lighteval | Python | [[FT]  Add tests for `VLLMModel` base methods](https://github.com/huggingface/lighteval/issues/724) | 0 |
-| huggingface/lighteval | Python | [[FT] Build in a way to specify specific IDs/Lines in Dataset to use as few-shot examples in the same split](https://github.com/huggingface/lighteval/issues/634) | 0 |
-| huggingface/nanotron | Python | [[Feature] Use CUDA event for measuring elasped time](https://github.com/huggingface/nanotron/issues/88) | 0 |
-| huggingface/nanotron | Python | [[Feature] Refactor `ParallelContext.world_rank_matrix`](https://github.com/huggingface/nanotron/issues/77) | 0 |
-| huggingface/optimum-executorch | Python | [Add benchmarking numbers for more models](https://github.com/huggingface/optimum-executorch/issues/131) | 0 |
-| ansible/ansible-jupyter-kernel | Python | [Add support for handlers](https://github.com/ansible/ansible-jupyter-kernel/issues/53) | 0 |
-| ansible/ansible-jupyter-kernel | Python | [Add a #library cell type](https://github.com/ansible/ansible-jupyter-kernel/issues/26) | 0 |
-| ansible/awx | Python | [[ui_next] Add All/Any workflow viz indication to Workflow Viz Legend/Key](https://github.com/ansible/awx/issues/9791) | 0 |
-| ansible/dispatcherd | Python | [Enforce UUID format, add "origin" information in message data](https://github.com/ansible/dispatcherd/issues/96) | 0 |
-| ansible/django-ansible-base | Python | [`ansible_base.lib.utils.models.diff` takes unused `sanitize_encrypted` param and has outdated return docstring](https://github.com/ansible/django-ansible-base/issues/688) | 0 |
-| canonical/admission-webhook-operator | Python | [Add missing unit tests](https://github.com/canonical/admission-webhook-operator/issues/21) | 0 |
-| canonical/charmcraft | Python | [Determine whether requiring `libyaml-devel` on yum-based systems creates working charms](https://github.com/canonical/charmcraft/issues/1771) | 0 |
-| canonical/cloud-init | Python | [Misleading ssh_redirect_user warning](https://github.com/canonical/cloud-init/issues/3924) | 0 |
-| canonical/cos-alerter | Python | [Covererage needs to be fixed](https://github.com/canonical/cos-alerter/issues/90) | 0 |
-| canonical/cos-coordinated-workers | Python | [Reword error status message for misconfigured worker](https://github.com/canonical/cos-coordinated-workers/issues/11) | 0 |
-| canonical/cos-lib | Python | [Feat: Improve Nginx performance](https://github.com/canonical/cos-lib/issues/145) | 0 |
-| canonical/cos-lib | Python | [add helper for discovering and aliasing system architecture](https://github.com/canonical/cos-lib/issues/29) | 0 |
-| canonical/cos-proxy-operator | Python | [Fix typing](https://github.com/canonical/cos-proxy-operator/issues/165) | 0 |
-| canonical/craft-providers | Python | [fix linter warnings](https://github.com/canonical/craft-providers/issues/325) | 0 |
-| canonical/istio-operators | Python | [Add test for changed `kind` in `istio-gateway`](https://github.com/canonical/istio-operators/issues/37) | 0 |
-| canonical/juju-sdk-tutorial-k8s | Python | [Use charmcraft.yaml's 'charm-libs' feature](https://github.com/canonical/juju-sdk-tutorial-k8s/issues/64) | 0 |
-| canonical/juju-sdk-tutorial-k8s | Python | [Possible race condition in getting the database credentials](https://github.com/canonical/juju-sdk-tutorial-k8s/issues/41) | 0 |
-| canonical/karma-alertmanager-proxy-k8s-operator | Python | [add option to clear the config and have the charm go back into BlockedState](https://github.com/canonical/karma-alertmanager-proxy-k8s-operator/issues/5) | 0 |
-| canonical/karma-alertmanager-proxy-k8s-operator | Python | [add config param for custom name for the proxied alertmanager cluster](https://github.com/canonical/karma-alertmanager-proxy-k8s-operator/issues/1) | 0 |
-| canonical/kubeflow-ci | Python | [add `kubectl describe nodes` to logdump](https://github.com/canonical/kubeflow-ci/issues/94) | 0 |
-| canonical/kubeflow-ci | Python | [add `juju status` to log dump action](https://github.com/canonical/kubeflow-ci/issues/69) | 0 |
-| canonical/microk8s-community-addons | Python | [ArgoCD addon should include the argocd CLI](https://github.com/canonical/microk8s-community-addons/issues/148) | 0 |
-| canonical/minio-operator | Python | [Broken charm icons for minio, mysql and katib-*](https://github.com/canonical/minio-operator/issues/45) | 0 |
-| canonical/minio-operator | Python | [Add `ingress` relation to expose console, api](https://github.com/canonical/minio-operator/issues/40) | 0 |
-| canonical/mlflow-operator | Python | [hardcoded aws default region](https://github.com/canonical/mlflow-operator/issues/21) | 0 |
-| canonical/parca-scrape-target-operator | Python | [Add CONTRIBUTING.md](https://github.com/canonical/parca-scrape-target-operator/issues/55) | 0 |
-| canonical/powershell-snaps | Python | [Create CI validation for release channel names](https://github.com/canonical/powershell-snaps/issues/20) | 0 |
-| canonical/prometheus-k8s-operator | Python | [Metrics are still received after Grafana Agent stops](https://github.com/canonical/prometheus-k8s-operator/issues/643) | 0 |
-| canonical/pycloudlib | Python | [Consistent console_log() API](https://github.com/canonical/pycloudlib/issues/363) | 0 |
-| canonical/redis-k8s-operator | Python | [Add integration tests that scale relating app](https://github.com/canonical/redis-k8s-operator/issues/48) | 0 |
-| canonical/script-exporter-operator | Python | [Change the path of script-exporter-script](https://github.com/canonical/script-exporter-operator/issues/12) | 0 |
-| pytorch/ao | Python | [Add weight tensor-wise scaling for INT8 quantized and mixed-precision training](https://github.com/pytorch/ao/issues/1010) | 1 |
-| pytorch/ao | Python | [MoE example ](https://github.com/pytorch/ao/issues/729) | 1 |
-| pytorch/ao | Python | [Self compressing neural networks](https://github.com/pytorch/ao/issues/658) | 1 |
-| pytorch/examples | Python | [Video classification example](https://github.com/pytorch/examples/issues/895) | 1 |
-| pytorch/examples | Python | [Resume will override learning rate on command line.](https://github.com/pytorch/examples/issues/816) | 1 |
-| pytorch/examples | Python | [A question about weight initialization of embedding layer.](https://github.com/pytorch/examples/issues/595) | 1 |
-| pytorch/examples | Python | [Changes needed to run DCGAN 32x32 ](https://github.com/pytorch/examples/issues/486) | 1 |
-| pytorch/examples | Python | [ImageFolder doc should clarify 1. order that images returned in 2. that all classes are concatenated into a single list](https://github.com/pytorch/examples/issues/400) | 1 |
-| pytorch/examples | Python | [Doc comment on `accuracy` method in imagenet example, incorrect?](https://github.com/pytorch/examples/issues/312) | 1 |
-| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.isinf`](https://github.com/pytorch/executorch/issues/18922) | 1 |
-| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for aten.flip](https://github.com/pytorch/executorch/issues/18918) | 1 |
-| pytorch/executorch | Python | [Add dynamism tests for xnnpack model tests](https://github.com/pytorch/executorch/issues/11585) | 1 |
-| pytorch/executorch | Python | [Implement load_into for the shared_ptr data loader](https://github.com/pytorch/executorch/issues/11562) | 1 |
-| pytorch/executorch | Python | [[Android] Use generic JNI instead of fbjni](https://github.com/pytorch/executorch/issues/10444) | 1 |
-| pytorch/PiPPy | Python | [Support LayoutLM models in HF tests](https://github.com/pytorch/PiPPy/issues/247) | 1 |
-| pytorch/text | Python | [torchtext main branch doesn't support pytorch2.0](https://github.com/pytorch/text/issues/2052) | 1 |
-| pytorch/torcharrow | Python | [Default aggregation functions delegates to Arrow Compute ](https://github.com/pytorch/torcharrow/issues/53) | 1 |
-| pytorch/torchchat | Python | [GeneratorArgs.is_torchtune_model is a misnomer](https://github.com/pytorch/torchchat/issues/1273) | 1 |
-| pytorch/torchtitan | Python | [Ability to train based on epoch](https://github.com/pytorch/torchtitan/issues/613) | 1 |
-| tensorflow/agents | Python | [Tutorial 1: Train a Deep Q Network with TF-Agents and the use of a driver](https://github.com/tensorflow/agents/issues/554) | 1 |
-| huggingface/accelerate | Python | [Deadlock when running multi tasks](https://github.com/huggingface/accelerate/issues/3814) | 1 |
-| huggingface/dataset-viewer | Python | [Use `revision_exists` (hfh)](https://github.com/huggingface/dataset-viewer/issues/2562) | 1 |
-| huggingface/diffusers | Python | [Do we have any script covert from hf format to orginal format?](https://github.com/huggingface/diffusers/issues/10076) | 1 |
-| huggingface/lerobot | Python | [Question regarding downsampling and resizing dataset](https://github.com/huggingface/lerobot/issues/2124) | 1 |
-| huggingface/lerobot | Python | [Ensure the teleoperators module passes MyPy type checks](https://github.com/huggingface/lerobot/issues/1726) | 1 |
-| huggingface/lighteval | Python | [[EVAL] Add kyrgyzLLM benchmark](https://github.com/huggingface/lighteval/issues/1036) | 1 |
-| huggingface/lighteval | Python | [[FT] Manage script and language in the Language enum](https://github.com/huggingface/lighteval/issues/745) | 1 |
-| huggingface/lighteval | Python | [[FT] LiteLLM concurrency parameters hard-coded](https://github.com/huggingface/lighteval/issues/567) | 1 |
-| huggingface/nanotron | Python | [Add Debug utility to be able to preview first samples used for training](https://github.com/huggingface/nanotron/issues/184) | 1 |
-| huggingface/nanotron | Python | [We don't save checkpoint after training ends](https://github.com/huggingface/nanotron/issues/163) | 1 |
-| huggingface/nanotron | Python | [FEAT: Support 1.58-bit LLMs training](https://github.com/huggingface/nanotron/issues/114) | 1 |
-| huggingface/nanotron | Python | [[Feature Request] Add simple communications benchmarks to the repo](https://github.com/huggingface/nanotron/issues/43) | 1 |
-| huggingface/sentence-transformers | Python | [Update example scripts relying on `http_get` to download from the Hugging Face Hub instead](https://github.com/huggingface/sentence-transformers/issues/3620) | 1 |
-| ansible/ansible-documentation | Python | [Need explanation that modules can only import from `module_utils` within the `ansible` namespace](https://github.com/ansible/ansible-documentation/issues/3442) | 1 |
-| ansible/ansible-documentation | Python | [Prune stub files in docs/docsite](https://github.com/ansible/ansible-documentation/issues/3228) | 1 |
-| ansible/ansible-navigator | Python | [Many params missing change after initial = False](https://github.com/ansible/ansible-navigator/issues/423) | 1 |
-| ansible/awx | Python | [Scheduled Job prompted extra_vars overwritten by JT extra_vars](https://github.com/ansible/awx/issues/14445) | 1 |
-| ansible/awx | Python | [Inaccurate error handling on Input Group Integer fields (i.e. Org Max Hosts field)](https://github.com/ansible/awx/issues/8556) | 1 |
-| ansible/awx | Python | [RFE: Send real client remote address in TACACS+ authentication packet](https://github.com/ansible/awx/issues/1797) | 1 |
-| ansible/django-ansible-base | Python | [Several unordered querysets](https://github.com/ansible/django-ansible-base/issues/178) | 1 |
-| canonical/charmed-postgresql-rock | Python | [Add integration test for verifying plugin shared objects consistency](https://github.com/canonical/charmed-postgresql-rock/issues/260) | 1 |
-| canonical/charmed-temporal-uats | Python | [Explore spread usage for UAT orchestration](https://github.com/canonical/charmed-temporal-uats/issues/14) | 1 |
-| canonical/charmed-temporal-uats | Python | [Add custom concierge config for desired environment for UATs](https://github.com/canonical/charmed-temporal-uats/issues/13) | 1 |
-| canonical/cos-proxy-operator | Python | [Wrongly formatted alert rules are silently not loaded](https://github.com/canonical/cos-proxy-operator/issues/166) | 1 |
-| canonical/craft-providers | Python | [fix type checking](https://github.com/canonical/craft-providers/issues/326) | 1 |
-| canonical/data-platform-workflows | Python | [Improve checks on `_promote_charms` action](https://github.com/canonical/data-platform-workflows/issues/369) | 1 |
-| canonical/dex-auth-operator | Python | [Expected content of `connectors` config is not intuitive, add validation and documentation](https://github.com/canonical/dex-auth-operator/issues/42) | 1 |
-| canonical/gh-jira-sync-bot | Python | [`status_mapping` seems broken](https://github.com/canonical/gh-jira-sync-bot/issues/39) | 1 |
-| canonical/karapace-operator | Python | [Karapace operator does not cleanup properly after TLS `relation-broken`](https://github.com/canonical/karapace-operator/issues/39) | 1 |
-| canonical/litmus-operators | Python | [use nginx module from charmlibs](https://github.com/canonical/litmus-operators/issues/122) | 1 |
-| canonical/pgbouncer-operator | Python | [Expose more configuration options](https://github.com/canonical/pgbouncer-operator/issues/579) | 1 |
-| canonical/pgbouncer-operator | Python | [Block the charm if there is no client relation](https://github.com/canonical/pgbouncer-operator/issues/252) | 1 |
-| canonical/postgresql-k8s-operator | Python | [Add test for DCS failsafe mode, simulating k8s API being down](https://github.com/canonical/postgresql-k8s-operator/issues/792) | 1 |
-| canonical/postgresql-k8s-operator | Python | [Test: scale application to zero units ](https://github.com/canonical/postgresql-k8s-operator/issues/508) | 1 |
-| canonical/postgresql-k8s-operator | Python | [Test charm recovery after instance restart.](https://github.com/canonical/postgresql-k8s-operator/issues/470) | 1 |
-| canonical/postgresql-k8s-operator | Python | [Improve config options validation](https://github.com/canonical/postgresql-k8s-operator/issues/295) | 1 |
-| canonical/postgresql-operator | Python | [Move `--log-level-stderr=warn` to pgBackRest's configuration file](https://github.com/canonical/postgresql-operator/issues/1353) | 1 |
-| canonical/postgresql-test-app | Python | [Create a nightly test run for self-checking](https://github.com/canonical/postgresql-test-app/issues/148) | 1 |
-| canonical/pycloudlib | Python | [Contributing guidelines seem outdated](https://github.com/canonical/pycloudlib/issues/377) | 1 |
-| canonical/pyroscope-operators | Python | [use nginx module from charmlibs](https://github.com/canonical/pyroscope-operators/issues/285) | 1 |
-| canonical/rockcraft | Python | [docs: Running Flask, Django and FastAPI should be in a code block](https://github.com/canonical/rockcraft/issues/1145) | 1 |
-| canonical/rockcraft | Python | [Help includes expand-extensions entry with reference to snapcraft.yaml](https://github.com/canonical/rockcraft/issues/658) | 1 |
-| canonical/spark-k8s-bundle | Python | [Make `secret-key`, `storage-account` and `container-name` fields required in TF variables for azure-storage](https://github.com/canonical/spark-k8s-bundle/issues/139) | 1 |
-| canonical/spark-k8s-toolkit-py | Python | [Prettify the output printed by the CLI commands](https://github.com/canonical/spark-k8s-toolkit-py/issues/56) | 1 |
-| canonical/tempo-operators | Python | [Wrong `LogQL` in dashboard](https://github.com/canonical/tempo-operators/issues/272) | 1 |
-| canonical/traefik-k8s-operator | Python | [Output the correct message when traefik is not deployed with --trust](https://github.com/canonical/traefik-k8s-operator/issues/589) | 1 |
-| canonical/traefik-k8s-operator | Python | [missing substitution in log message](https://github.com/canonical/traefik-k8s-operator/issues/439) | 1 |
-| canonical/ubuntu-security-documentation | Python | [[security-features] `cloud-prng-seed.rst` contains dead links](https://github.com/canonical/ubuntu-security-documentation/issues/80) | 1 |
-| canonical/ubuntu-security-documentation | Python | [[compliance] Add links for mentioned standards](https://github.com/canonical/ubuntu-security-documentation/issues/77) | 1 |
-| pytorch/ao | Python | [Resolve doc build warnings](https://github.com/pytorch/ao/issues/3863) | 2 |
-| pytorch/ao | Python | [Refactor torchao and tests to use model architectures from torchao.testing.model_architectures](https://github.com/pytorch/ao/issues/2078) | 2 |
-| pytorch/ao | Python | [Unittests Migration Progress](https://github.com/pytorch/ao/issues/1621) | 2 |
-| pytorch/ao | Python | [[MX | Triton] Create MX matmul op using new `scaled_dot` op in Triton](https://github.com/pytorch/ao/issues/1084) | 2 |
-| pytorch/ao | Python | [Support for GrokAdamW](https://github.com/pytorch/ao/issues/1032) | 2 |
-| pytorch/ao | Python | [Tensor subclass boilerplate can be consolidated](https://github.com/pytorch/ao/issues/710) | 2 |
-| pytorch/ao | Python | [[RFC] Intx Tensor Subclasses Quantization](https://github.com/pytorch/ao/issues/439) | 2 |
-| pytorch/examples | Python | [Update all examples to latest versions of pytorch](https://github.com/pytorch/examples/issues/976) | 2 |
-| pytorch/examples | Python | [Warning: an output with one or more elements was resized since it had shape[xxxx],]](https://github.com/pytorch/examples/issues/937) | 2 |
-| pytorch/examples | Python | [Add nn.SyncBatchNorm in ImageNet example](https://github.com/pytorch/examples/issues/793) | 2 |
-| pytorch/examples | Python | [mnist example contains bad practices leading to wrongful results](https://github.com/pytorch/examples/issues/623) | 2 |
-| pytorch/examples | Python | [Input type and weight type should be the same](https://github.com/pytorch/examples/issues/599) | 2 |
-| pytorch/examples | Python | [please use longer names for variables than 2-3 letter acronyms](https://github.com/pytorch/examples/issues/487) | 2 |
-| pytorch/examples | Python | [VAE reconstruction loss (BCE) ](https://github.com/pytorch/examples/issues/460) | 2 |
-| pytorch/examples | Python | [Imagenet training extremely low gpu utilization](https://github.com/pytorch/examples/issues/387) | 2 |
-| pytorch/examples | Python | [Ambiguous code in reinforce](https://github.com/pytorch/examples/issues/297) | 2 |
-| pytorch/executorch | Python | [Good First Issue: Add Full Integer Support for `aten.bitwise_and`](https://github.com/pytorch/executorch/issues/18925) | 2 |
-| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.trunc`](https://github.com/pytorch/executorch/issues/18923) | 2 |
-| pytorch/executorch | Python | [[Arm] Size-test: Run the binary on CI](https://github.com/pytorch/executorch/issues/12812) | 2 |
-| pytorch/executorch | Python | [Consolidation of Selective Build APIs for OSS](https://github.com/pytorch/executorch/issues/11921) | 2 |
-| pytorch/executorch | Python | [Support dim order in Java Tensor](https://github.com/pytorch/executorch/issues/11593) | 2 |
-| pytorch/executorch | Python | [Add torchao kernels to xcframework](https://github.com/pytorch/executorch/issues/10694) | 2 |
-| pytorch/executorch | Python | [Need a feature to get etdump while running LLAMA model on qnn with qnn_llama_runner](https://github.com/pytorch/executorch/issues/10580) | 2 |
-| pytorch/executorch | Python | [[Request impl] Gracefully error out in ETDump](https://github.com/pytorch/executorch/issues/9971) | 2 |
-| pytorch/PiPPy | Python | [Make RemoteInterpreter use the full implementation of `Interpreter.run`](https://github.com/pytorch/PiPPy/issues/25) | 2 |
-| pytorch/pytorch | Python | [[BE] Deduplicate auto_functionalized and triton_kernel_wrapper_functional](https://github.com/pytorch/pytorch/issues/133443) | 2 |
-| pytorch/pytorch | Python | [[PT2] [Hardening] Track recompiles alongside graph breaks in our actual/expected comparison CI runs](https://github.com/pytorch/pytorch/issues/113040) | 2 |
-| pytorch/rl | Python | [[Feature Request] Make sure that all losses work with tensorclasses and regular tensors](https://github.com/pytorch/rl/issues/1062) | 2 |
-| pytorch/rl | Python | [[Feature Request] TensorSpec is_in methods should check the dtype of val](https://github.com/pytorch/rl/issues/793) | 2 |
-| pytorch/text | Python | [Convert iterator-style raw datasets to map-style raw datasets](https://github.com/pytorch/text/issues/1296) | 2 |
-| pytorch/torchchat | Python | [torchtune as an optional dependency: Lazy Import](https://github.com/pytorch/torchchat/issues/1519) | 2 |
-| pytorch/torchchat | Python | [Slimming down torchchat: Replace replace_attention_with_custom_sdpa_attention() with ET's implementation](https://github.com/pytorch/torchchat/issues/1058) | 2 |
-| tensorflow/graphics | Python | [Tangential camera distortion/undistortion](https://github.com/tensorflow/graphics/issues/334) | 2 |
-| huggingface/dataset-viewer | Python | [use the `ROW_IDX_COLUMN` constant name instead of copying the value everywhere](https://github.com/huggingface/dataset-viewer/issues/2798) | 2 |
-| huggingface/dataset-viewer | Python | [Use "Sign-In with HF" instead of token in admin-UI](https://github.com/huggingface/dataset-viewer/issues/2373) | 2 |
-| huggingface/lerobot | Python | [Finetune smolvla with vision encoder](https://github.com/huggingface/lerobot/issues/1774) | 2 |
-| huggingface/lighteval | Python | [Call for contributions: Translate lighteval's doc into Chinese](https://github.com/huggingface/lighteval/issues/716) | 2 |
-| huggingface/nanotron | Python | [[Feature] Asyncronous Serialization](https://github.com/huggingface/nanotron/issues/87) | 2 |
-| huggingface/nanotron | Python | [[Feature Request] Support Data Streaming for faster training of large models](https://github.com/huggingface/nanotron/issues/45) | 2 |
-| ansible/ansible-navigator | Python | [Switch to the use of `pathlib` where possible](https://github.com/ansible/ansible-navigator/issues/697) | 2 |
-| ansible/awx | Python | [Empty value in execution_environment should remove selections (ansible.controller.job_template)](https://github.com/ansible/awx/issues/14841) | 2 |
-| ansible/awx | Python | [Issue label for incompliance with Ansible](https://github.com/ansible/awx/issues/13272) | 2 |
-| ansible/awx | Python | [New credentials type to provide VAULT_ADDR and VAULT_TOKEN env vars](https://github.com/ansible/awx/issues/13117) | 2 |
-| ansible/awx | Python | [Expose the value of "Execution Node" as a variable when running a job from Ansible Tower.](https://github.com/ansible/awx/issues/8122) | 2 |
-| ansible/awx | Python | ["Playbook not found for project" error when the playbook exist but is invalid ](https://github.com/ansible/awx/issues/6842) | 2 |
-| ansible/awx | Python | [Jobs canceled before starting should not show a "finished" time](https://github.com/ansible/awx/issues/3988) | 2 |
-| ansible/awx | Python | [Make Info Metrics more easy to query](https://github.com/ansible/awx/issues/3781) | 2 |
-| ansible/awx | Python | [weekly dashboard view does not have sufficient granularity](https://github.com/ansible/awx/issues/3060) | 2 |
-| canonical/charmcraft | Python | [Improve the 'release' response when resources are automatically released with the charm](https://github.com/canonical/charmcraft/issues/847) | 2 |
-| canonical/charmed-postgresql-snap | Python | [`start-pgbackrest-exporter.sh` does not support non-snapped environments](https://github.com/canonical/charmed-postgresql-snap/issues/169) | 2 |
-| canonical/cloud-init | Python | [[docs]: some DataSources missing from docs](https://github.com/canonical/cloud-init/issues/5341) | 2 |
-| canonical/cloud-init | Python | [[docs]: The terms "#include" and "#include-once" are difficult to define in the documentation](https://github.com/canonical/cloud-init/issues/4408) | 2 |
-| canonical/gh-jira-sync-bot | Python | [Issue is created on closure](https://github.com/canonical/gh-jira-sync-bot/issues/40) | 2 |
-| canonical/istio-operators | Python | [istio-pilot should look for signs of another istio install during deployment](https://github.com/canonical/istio-operators/issues/104) | 2 |
-| canonical/istio-operators | Python | [`ingress-auth` relation does not work for cross-model relations, needs `namespace` property in schema](https://github.com/canonical/istio-operators/issues/48) | 2 |
-| canonical/katib-operators | Python | [katib-* missing unit and integration tests](https://github.com/canonical/katib-operators/issues/5) | 2 |
-| canonical/microk8s-community-addons | Python | [Add support for Istio 1.16, 1.17 and1.18](https://github.com/canonical/microk8s-community-addons/issues/152) | 2 |
-| canonical/mysql-operators | Python | [[k8s] Memory consumption calculation skewed up desproportionally for smaller (<3G) deployments](https://github.com/canonical/mysql-operators/issues/18) | 2 |
-| canonical/postgresql-k8s-operator | Python | [PostgreSQL K8s charm failed to deploy after removing with `--force --no-wait` (due to K8s service availability)](https://github.com/canonical/postgresql-k8s-operator/issues/1171) | 2 |
-| canonical/postgresql-operator | Python | [Running list-backups actions shortly after relation with s3-integrator results in IndexError](https://github.com/canonical/postgresql-operator/issues/699) | 2 |
-| canonical/pycloudlib | Python | [build status badge is obsolete in README.md](https://github.com/canonical/pycloudlib/issues/445) | 2 |
-| canonical/snapcraft | Python | [Add "--base=core2x"" option to "snapcraft extensions"](https://github.com/canonical/snapcraft/issues/4360) | 2 |
-| canonical/specs.canonical.com | Python | [reviewers parser should ignore wrong cases](https://github.com/canonical/specs.canonical.com/issues/12) | 2 |
-| canonical/tempo-operators | Python | [Annoying tracing lib warning: charm tracing buffer exceeds max history length (100 events)](https://github.com/canonical/tempo-operators/issues/257) | 2 |
-| canonical/tempo-operators | Python | [Handle multiple ingresses cleanly](https://github.com/canonical/tempo-operators/issues/245) | 2 |
-| canonical/traefik-k8s-operator | Python | [Refactor or remove `redirect_https` from the ingress/ingress-per-app interface](https://github.com/canonical/traefik-k8s-operator/issues/502) | 2 |
-| pytorch/ao | Python | [FP8 Blockwise Training Tracker](https://github.com/pytorch/ao/issues/3290) | 3 |
-| pytorch/ao | Python | [[QAT] Low-bit FSDP all-gather for QAT](https://github.com/pytorch/ao/issues/1224) | 3 |
-| pytorch/ao | Python | [[sparse] Add GPTQ support for sparse-marlin](https://github.com/pytorch/ao/issues/1134) | 3 |
-| pytorch/ao | Python | [Tensor Parallelism Support for AffineQuantizedTensor](https://github.com/pytorch/ao/issues/988) | 3 |
-| pytorch/examples | Python | [word_language_model with torch.nn.modules.transformer](https://github.com/pytorch/examples/issues/1112) | 3 |
-| pytorch/examples | Python | [OSError: [Errno 22] Invalid argument:](https://github.com/pytorch/examples/issues/887) | 3 |
-| pytorch/examples | Python | [MNIST test_loader not being used as intended (wrong)!](https://github.com/pytorch/examples/issues/756) | 3 |
-| pytorch/examples | Python | [Actor critic example not using discount rate properly](https://github.com/pytorch/examples/issues/744) | 3 |
-| pytorch/examples | Python | ["omit freeze_support"](https://github.com/pytorch/examples/issues/323) | 3 |
-| pytorch/executorch | Python | [torch.split fails in to_edge](https://github.com/pytorch/executorch/issues/11723) | 3 |
-| pytorch/executorch | Python | [Support Standalone Batch Norm](https://github.com/pytorch/executorch/issues/11586) | 3 |
-| pytorch/executorch | Python | [[Android] Rename JNI cpp file](https://github.com/pytorch/executorch/issues/10890) | 3 |
-| pytorch/executorch | Python | [Get rid of fixed number cmake --build -j in sh and docs](https://github.com/pytorch/executorch/issues/10887) | 3 |
-| pytorch/executorch | Python | [Consolidate executor_runners](https://github.com/pytorch/executorch/issues/10819) | 3 |
-| pytorch/pytorch | Python | [[Docathon] Convert `nn.init.rst` from rST to MyST Markdown](https://github.com/pytorch/pytorch/issues/182479) | 3 |
-| pytorch/pytorch | Python | [[auto functionalize][partitioner] ones_like is not getting recomputed](https://github.com/pytorch/pytorch/issues/170160) | 3 |
-| pytorch/torchchat | Python | [Improve Tokenizer New Type Onboarding](https://github.com/pytorch/torchchat/issues/1536) | 3 |
-| pytorch/torchchat | Python | [[UX] We are too quiet about errors - in particular missing HF authentication...](https://github.com/pytorch/torchchat/issues/782) | 3 |
-| pytorch/torchdistx | Python | [Documentation for AnyPrecisionOptimizer](https://github.com/pytorch/torchdistx/issues/61) | 3 |
-| tensorflow/addons | Python | [Benchmark test for rrelu fails on windows](https://github.com/tensorflow/addons/issues/839) | 3 |
-| tensorflow/graphics | Python | [Add skew to projective camera](https://github.com/tensorflow/graphics/issues/335) | 3 |
-| tensorflow/model-card-toolkit | Python | [Prefer single quote strings model-card-toolkit](https://github.com/tensorflow/model-card-toolkit/issues/279) | 3 |
-| tensorflow/similarity | Python | [Add a ranking example](https://github.com/tensorflow/similarity/issues/199) | 3 |
-| godotengine/godot-blender-exporter | Python | [Blender object with negative scale](https://github.com/godotengine/godot-blender-exporter/issues/24) | 3 |
-| huggingface/dataset-viewer | Python | [Use `CONSTANT_LIST.copy` in list config fieds](https://github.com/huggingface/dataset-viewer/issues/1522) | 3 |
-| huggingface/lighteval | Python | [[FT] showing count in Markdown summary table](https://github.com/huggingface/lighteval/issues/804) | 3 |
-| huggingface/lighteval | Python | [[FT]  Add tests for nanotron](https://github.com/huggingface/lighteval/issues/765) | 3 |
-| huggingface/lighteval | Python | [[EVAL] Big-Bench Extra Hard (BBEH)](https://github.com/huggingface/lighteval/issues/600) | 3 |
-| huggingface/optimum | Python | [Add all available ONNX models to ORTConfigManager](https://github.com/huggingface/optimum/issues/351) | 3 |
-| huggingface/optimum-habana | Python | [Add support for max_length in run_generation](https://github.com/huggingface/optimum-habana/issues/472) | 3 |
-| huggingface/transfer-learning-conv-ai | Python | [RuntimeError: shape '[-1, 2, 34]' is invalid for input of size 61710](https://github.com/huggingface/transfer-learning-conv-ai/issues/12) | 3 |
-| ansible/ansible-documentation | Python | [Incorporate 'shared snippets' for the collection docs into the main rst files](https://github.com/ansible/ansible-documentation/issues/1382) | 3 |
-| ansible/awx | Python | [Fix Delinea imports and import test](https://github.com/ansible/awx/issues/14703) | 3 |
-| ansible/awx | Python | [Cleanup Job Details. Configure days retention for the particular job entities. ](https://github.com/ansible/awx/issues/14384) | 3 |
-| ansible/awx | Python | [Improve user experience of copy pasting FQDNs from jobs](https://github.com/ansible/awx/issues/14354) | 3 |
-| ansible/awx | Python | [Non descriptive error when podman is missing](https://github.com/ansible/awx/issues/14341) | 3 |
-| ansible/awx | Python | [Add "nodes" to "Relaunch on" when relaunching jobs after failure - users think it relates to failed tasks and not nodes](https://github.com/ansible/awx/issues/12438) | 3 |
-| ansible/awx | Python | [Worker failed to run task awx.main.tasks.system.purge_old_stdout_files](https://github.com/ansible/awx/issues/11903) | 3 |
-| ansible/awx | Python | [System Auditors can check list items](https://github.com/ansible/awx/issues/10841) | 3 |
-| ansible/awx | Python | [Show more host information in host filter lookup list ](https://github.com/ansible/awx/issues/7853) | 3 |
-| ansible/awx | Python | [Inconsistent capitalization across ui-next ](https://github.com/ansible/awx/issues/7037) | 3 |
-| ansible/awx | Python | [User auth field not documented in OPTIONS](https://github.com/ansible/awx/issues/2301) | 3 |
-| canonical/charmcraft | Python | [The analyze command should also work on a not-packed charm](https://github.com/canonical/charmcraft/issues/642) | 3 |
-| canonical/cloud-init | Python | [Don't Depend on GNU Date](https://github.com/canonical/cloud-init/issues/4357) | 3 |
-| canonical/cloud-init | Python | [[docs]: Default behaviour of ConfigDrive is unclear](https://github.com/canonical/cloud-init/issues/4310) | 3 |
-| canonical/cloud-init | Python | [Wrong return_code in analyze boot](https://github.com/canonical/cloud-init/issues/4245) | 3 |
-| canonical/cloud-init | Python | [cc_grub_dpkg: race condition on dpkg-set-selections lock](https://github.com/canonical/cloud-init/issues/4010) | 3 |
-| canonical/cloud-init | Python | [docs: update rtd documentation for altcloud](https://github.com/canonical/cloud-init/issues/3968) | 3 |
-| canonical/cloud-init | Python | [cloud-init network config 2 rename does not match with name](https://github.com/canonical/cloud-init/issues/3229) | 3 |
-| canonical/open-documentation-academy | Python | [[Ubuntu Project] Add (describe) a glossary term: branch](https://github.com/canonical/open-documentation-academy/issues/246) | 3 |
-| canonical/pgbouncer-operator | Python | [Add configuration for max_prepared_statements](https://github.com/canonical/pgbouncer-operator/issues/425) | 3 |
-| canonical/redis-k8s-operator | Python | [Add integration test coverage for HA of metrics exporter](https://github.com/canonical/redis-k8s-operator/issues/86) | 3 |
-| canonical/snapcraft | Python | [Recommend using newer versions of snapcraft](https://github.com/canonical/snapcraft/issues/4958) | 3 |
-| canonical/testflinger | Python | [Add website URL field for agents](https://github.com/canonical/testflinger/issues/794) | 3 |
-| canonical/test_observer | Python | [UI is unusable to bulk approve large number of environments.](https://github.com/canonical/test_observer/issues/736) | 3 |
-| pytorch/ao | Python | [[llama] Use horizontal fusion trick from Attention for FeedForward](https://github.com/pytorch/ao/issues/606) | 4 |
-| pytorch/ao | Python | [Quantized Training](https://github.com/pytorch/ao/issues/554) | 4 |
-| pytorch/examples | Python | [Please change dcgan to load truncated images.](https://github.com/pytorch/examples/issues/835) | 4 |
-| pytorch/examples | Python | [No matching function call  error in custom_dataset example ](https://github.com/pytorch/examples/issues/680) | 4 |
-| pytorch/examples | Python | [Add Siamese Network example](https://github.com/pytorch/examples/issues/645) | 4 |
-| pytorch/executorch | Python | [Re-inplace slice_copy with slice](https://github.com/pytorch/executorch/issues/10917) | 4 |
-| pytorch/pytorch | Python | [[export] Schematize nn_module_stack serialization](https://github.com/pytorch/pytorch/issues/131941) | 4 |
-| pytorch/pytorch | Python | [switch more test cases to use MultithreadTestCase](https://github.com/pytorch/pytorch/issues/108744) | 4 |
-| tensorflow/graphics | Python | [Add ScanNet dataset](https://github.com/tensorflow/graphics/issues/307) | 4 |
-| huggingface/accelerate | Python | [[Community Contributions] examples on distributed inference using 🤗 Accelerate](https://github.com/huggingface/accelerate/issues/3078) | 4 |
-| huggingface/dataset-viewer | Python | [Cache/Queue metrics should not be negative](https://github.com/huggingface/dataset-viewer/issues/2495) | 4 |
-| huggingface/lerobot | Python | [How can I change the task name of already recorded episodes?](https://github.com/huggingface/lerobot/issues/2096) | 4 |
-| huggingface/lerobot | Python | [Ensure the utilities module passes MyPy type checks](https://github.com/huggingface/lerobot/issues/1727) | 4 |
-| huggingface/lighteval | Python | [[EVAL]: Add more African Benchmarks](https://github.com/huggingface/lighteval/issues/373) | 4 |
-| ansible/ansible-documentation | Python | [Link to devel in the various roadmaps](https://github.com/ansible/ansible-documentation/issues/1865) | 4 |
-| ansible/awx | Python | [ visualizer info field ](https://github.com/ansible/awx/issues/14597) | 4 |
-| ansible/awx | Python | [Remove some of the eslint-disable comments](https://github.com/ansible/awx/issues/11707) | 4 |
-| ansible/awx | Python | [Docker install instructions do not mention how to add awx-logos](https://github.com/ansible/awx/issues/11593) | 4 |
-| canonical/cloud-init | Python | [[docs]: The term "module" does not appear to be rigorously defined in the documentation](https://github.com/canonical/cloud-init/issues/4407) | 4 |
-| canonical/cloud-init | Python | [World writable /usr/lib/cloud-init/clouddir should not be left behind](https://github.com/canonical/cloud-init/issues/4189) | 4 |
-| canonical/cloud-init | Python | [genisoimage may be going away](https://github.com/canonical/cloud-init/issues/3838) | 4 |
-| canonical/cos-lib | Python | [better tests for unhappy paths](https://github.com/canonical/cos-lib/issues/100) | 4 |
-| canonical/kfp-operators | Python | [Change the default bucket name for Argo Workflows - currently always mlpipeline](https://github.com/canonical/kfp-operators/issues/132) | 4 |
-| canonical/oidc-gatekeeper-operator | Python | [`client-secret` isn't used.](https://github.com/canonical/oidc-gatekeeper-operator/issues/27) | 4 |
-| canonical/open-documentation-academy | Python | [Launchpad: Add an info box on the discontinuation of support for Bazaar](https://github.com/canonical/open-documentation-academy/issues/240) | 4 |
-| canonical/rockcraft | Python | [Improve detection/setting of the PATH environment variable](https://github.com/canonical/rockcraft/issues/729) | 4 |
-| django/djangoproject.com | Python | [Documentation table of contents is hard to reach on mobile devices](https://github.com/django/djangoproject.com/issues/494) | 4 |
-| pytorch/ao | Python | [[low-bit optim] Add COAT optimizer](https://github.com/pytorch/ao/issues/1190) | 5 |
-| pytorch/ao | Python | [The next tutorials](https://github.com/pytorch/ao/issues/426) | 5 |
-| pytorch/audio | Python | [read mp3 file fail](https://github.com/pytorch/audio/issues/2867) | 5 |
-| pytorch/executorch | Python | [Good First Issue: Enable Gemma 4 on MLX Backend](https://github.com/pytorch/executorch/issues/18928) | 5 |
-| pytorch/executorch | Python | [Good First Issue: Add MLX Op Handler for `aten.bitwise_xor`](https://github.com/pytorch/executorch/issues/18927) | 5 |
-| pytorch/pytorch | Python | [[Docathon] Convert `elastic/run.rst` from rST to MyST Markdown](https://github.com/pytorch/pytorch/issues/182472) | 5 |
-| pytorch/pytorch | Python | [Use typing_extensions.TypeAliasType for better reexport of `__module__`](https://github.com/pytorch/pytorch/issues/171905) | 5 |
-| pytorch/pytorch | Python | [Report WHY a symbol was created dynamically in symbolic_shapes logs](https://github.com/pytorch/pytorch/issues/137527) | 5 |
-| pytorch/pytorch | Python | [torch.fx.Tracer.record_stack_traces is broken in torch 2.4.0](https://github.com/pytorch/pytorch/issues/130861) | 5 |
-| pytorch/pytorch | Python | [refactor TracingContext to take a more limited subset of ViewAndMutationMeta](https://github.com/pytorch/pytorch/issues/114403) | 5 |
-| pytorch/rl | Python | [[Feature Request] Missing ActionScaling and FlattenAction ](https://github.com/pytorch/rl/issues/1209) | 5 |
-| tensorflow/graphics | Python | [Not detecting TF Nightly when installing from whl.](https://github.com/tensorflow/graphics/issues/305) | 5 |
-| tensorflow/similarity | Python | [Implement multi-siam for segmentation](https://github.com/tensorflow/similarity/issues/179) | 5 |
-| huggingface/accelerate | Python | [Barebones dataloader to allow for any type of iterable dataloader-like object to be used. Should just handle device placement](https://github.com/huggingface/accelerate/issues/2975) | 5 |
-| huggingface/lighteval | Python | [[BUG] custom model docs don't run: missing imports](https://github.com/huggingface/lighteval/issues/760) | 5 |
-| huggingface/lighteval | Python | [Append revision to filepath in `--output_dir`?](https://github.com/huggingface/lighteval/issues/56) | 5 |
-| huggingface/nanotron | Python | [Avoid nested `InheritFromOtherOptimizer`](https://github.com/huggingface/nanotron/issues/267) | 5 |
-| huggingface/nanotron | Python | [[Bug] Missing `_is_using_mup` when resume checkpoint](https://github.com/huggingface/nanotron/issues/198) | 5 |
-| huggingface/nanotron | Python | [[Unit Test] Add unit tests for DistributedTrainer](https://github.com/huggingface/nanotron/issues/90) | 5 |
-| huggingface/optimum-benchmark | Python | [Evaluators for specific tasks](https://github.com/huggingface/optimum-benchmark/issues/34) | 5 |
-| huggingface/sentence-transformers | Python | [Update example scripts relying on `model.fit` to use `SentenceTransformerTrainer` instead](https://github.com/huggingface/sentence-transformers/issues/3621) | 5 |
-| ansible/awx | Python | [Add option to force the user to reset its password at first login](https://github.com/ansible/awx/issues/15766) | 5 |
-| ansible/awx | Python | [ adhoc jobs block other jobs from being processed in the queue](https://github.com/ansible/awx/issues/14645) | 5 |
-| ansible/awx | Python | [all cluster nodes in development environment have the same UUID](https://github.com/ansible/awx/issues/13029) | 5 |
-| canonical/gh-jira-sync-bot | Python | [GH issue with two labels causes two jira tickets created](https://github.com/canonical/gh-jira-sync-bot/issues/71) | 5 |
-| canonical/postgresql-operator | Python | [Improve config options validation](https://github.com/canonical/postgresql-operator/issues/258) | 5 |
-| canonical/spark-integration-hub-k8s-operator | Python | [Charm errors when related to the s3-integrator and bucket name is empty](https://github.com/canonical/spark-integration-hub-k8s-operator/issues/150) | 5 |
-| django/djangoproject.com | Python | [fundraising: 'customer.subscription.deleted' webhook event always gets 404 response](https://github.com/django/djangoproject.com/issues/764) | 5 |
-| pytorch/ao | Python | [Accelerate activation sparsity with activation compression](https://github.com/pytorch/ao/issues/1920) | 6 |
-| pytorch/executorch | Python | [Manual kernel registration to include library names in API](https://github.com/pytorch/executorch/issues/11221) | 6 |
-| pytorch/ignite | Python | [Updating getting started to add code for the setup_tb_logger](https://github.com/pytorch/ignite/issues/3735) | 6 |
-| pytorch/pytorch | Python | [AOTAutograd: functionalization should emit foreach_copy_() instead of copy_() when possible](https://github.com/pytorch/pytorch/issues/119191) | 6 |
-| pytorch/pytorch | Python | [[dynamo] Missing support for many trivial builtin functions in operator](https://github.com/pytorch/pytorch/issues/116396) | 6 |
-| pytorch/pytorch | Python | [Enable ruff rule PLW1510 codebase wide](https://github.com/pytorch/pytorch/issues/115016) | 6 |
-| tensorflow/similarity | Python | [Create a colab for single shot to demonstrate how augmenters works](https://github.com/tensorflow/similarity/issues/74) | 6 |
-| huggingface/lerobot | Python | [Distributed v2.1 -> v3.0 conversion](https://github.com/huggingface/lerobot/issues/1998) | 6 |
-| huggingface/lighteval | Python | [[FT] Improve Documentation and Examples](https://github.com/huggingface/lighteval/issues/682) | 6 |
-| ansible/ansible-documentation | Python | [Misleading statement about "defaults" and "vars" sub-folders of roles](https://github.com/ansible/ansible-documentation/issues/2994) | 6 |
-| ansible/ansible-navigator | Python | [Allow to set ansible-runner artifacts dir ID ](https://github.com/ansible/ansible-navigator/issues/521) | 6 |
-| ansible/awx | Python | [AWX Collection Credential Delete](https://github.com/ansible/awx/issues/14209) | 6 |
-| canonical/cloud-init | Python | [[enhancement]: Relocate json schemas somewhere more sensible](https://github.com/canonical/cloud-init/issues/4688) | 6 |
-| canonical/open-documentation-academy | Python | [LXD: configure `cloud-init` from a file](https://github.com/canonical/open-documentation-academy/issues/63) | 6 |
-| django/djangoproject.com | Python | [Support switching languages on non-docs sites](https://github.com/django/djangoproject.com/issues/883) | 6 |
-| pytorch/examples | Python | [Why don't we use MSE as a reconstruction loss for VAE ?](https://github.com/pytorch/examples/issues/399) | 7 |
-| pytorch/executorch | Python | [Rename `executorch` cmake target to `prim_ops_lib`](https://github.com/pytorch/executorch/issues/11761) | 7 |
-| pytorch/executorch | Python | [Add timestamps for pte generation in CI](https://github.com/pytorch/executorch/issues/10761) | 7 |
-| pytorch/executorch | Python | [[Request Impl] Apply Segment Serialization in Bundled Program](https://github.com/pytorch/executorch/issues/9771) | 7 |
-| pytorch/pytorch | Python | [Enable more flake8-pyi ruff checks](https://github.com/pytorch/pytorch/issues/110950) | 7 |
-| tensorflow/similarity | Python | [Implement SwAV for self-supervised learning](https://github.com/tensorflow/similarity/issues/208) | 7 |
-| huggingface/lighteval | Python | [[EVAL] Long Horizon Execution](https://github.com/huggingface/lighteval/issues/1056) | 7 |
-| ansible/ansible-lint | Python | ['format' option missing from configuration file schema](https://github.com/ansible/ansible-lint/issues/4898) | 7 |
-| canonical/cloud-init | Python | [[enhancement]: fix typing of untyped-defs](https://github.com/canonical/cloud-init/issues/5445) | 7 |
-| canonical/cloud-init | Python | [ssh_import_id does not work on default user](https://github.com/canonical/cloud-init/issues/4306) | 7 |
-| canonical/cloud-init | Python | [package-update-upgrade-install does not update when run with --frequency=always](https://github.com/canonical/cloud-init/issues/3218) | 7 |
-| canonical/cos-lib | Python | [allow using cosl.coordinated_workers.S3ConnectionInfo outside of tempo-loki-mimir](https://github.com/canonical/cos-lib/issues/119) | 7 |
-| canonical/open-documentation-academy | Python | [[Ubuntu Project] Add (describe) a glossary term: Continuous Integration (CI)](https://github.com/canonical/open-documentation-academy/issues/272) | 7 |
-| canonical/open-documentation-academy | Python | [Launchpad: fix broken links](https://github.com/canonical/open-documentation-academy/issues/78) | 7 |
-| django/djangoproject.com | Python | [Redirect from /about to /foundation](https://github.com/django/djangoproject.com/issues/2428) | 7 |
-| django/djangoproject.com | Python | [Add link to new minutes repo](https://github.com/django/djangoproject.com/issues/2079) | 7 |
-| django/djangoproject.com | Python | [Improve Documentation by having list of topics fixed on the left and table of contents on the right ](https://github.com/django/djangoproject.com/issues/1129) | 7 |
-| django/djangoproject.com | Python | [Docs for old supported versions should indicate that a newer version is available](https://github.com/django/djangoproject.com/issues/1122) | 7 |
-| pytorch/pytorch | Python | [[BUG][PyTorch 2.0 Export][quant]:get_source_partitions() may return different matches with same input graph](https://github.com/pytorch/pytorch/issues/147170) | 8 |
-| huggingface/diffusers | Python | [Make `FlaxLMSDiscreteScheduler` jittable](https://github.com/huggingface/diffusers/issues/2180) | 8 |
-| huggingface/lerobot | Python | [Select the VLM backbone for SmolVLA](https://github.com/huggingface/lerobot/issues/2104) | 8 |
-| huggingface/lighteval | Python | [[EVAL] Adding PHARE](https://github.com/huggingface/lighteval/issues/696) | 8 |
-| ansible/ansible-documentation | Python | [Link "see also" sections as recommended in the forum](https://github.com/ansible/ansible-documentation/issues/1200) | 8 |
-| ansible/awx | Python | [Display SAML login icon for /api/login page](https://github.com/ansible/awx/issues/12905) | 8 |
-| canonical/open-documentation-academy | Python | [Rockcraft: Update text to American spelling](https://github.com/canonical/open-documentation-academy/issues/332) | 8 |
-| canonical/open-documentation-academy | Python | [MicroCeph: Replace :doc: with :ref: targets for internal cross-reference links (3)](https://github.com/canonical/open-documentation-academy/issues/279) | 8 |
-| django/djangoproject.com | Python | [Improvements to the Corporate Sponsor Experience](https://github.com/django/djangoproject.com/issues/1171) | 8 |
-| django/djangoproject.com | Python | [Use noindex meta tag or header, not robots.txt, to block untranslated docs pages](https://github.com/django/djangoproject.com/issues/877) | 8 |
-| pytorch/audio | Python | [Use non-persistent buffers](https://github.com/pytorch/audio/issues/3059) | 9 |
-| pytorch/pytorch | Python | [Improve error message for wrong number of arguments in CachingAutotuner](https://github.com/pytorch/pytorch/issues/146018) | 9 |
-| pytorch/pytorch | Python | [dynamo (re)compilation issues: shape (1,1), nn.Parameter, mark_dynamic](https://github.com/pytorch/pytorch/issues/135011) | 9 |
-| pytorch/pytorch | Python | [[Dynamo] Support tracing through _get_current_dispatch_mode_stack](https://github.com/pytorch/pytorch/issues/125694) | 9 |
-| tensorflow/similarity | Python | [Lifted Structured loss](https://github.com/tensorflow/similarity/issues/102) | 9 |
-| huggingface/diffusers | Python | [Support multiple control nets in the `StableDiffusionControlNetXSPipeline`/`StableDiffusionXLControlNetXSPipeline`](https://github.com/huggingface/diffusers/issues/8434) | 9 |
-| canonical/open-documentation-academy | Python | [Website: Create an article summarizing the presentation "Documentation as code" done by Robert Kratky](https://github.com/canonical/open-documentation-academy/issues/229) | 9 |
-| django/djangoproject.com | Python | [Remove non-canonical docs versions from sitemap.xml](https://github.com/django/djangoproject.com/issues/878) | 9 |
-| pytorch/executorch | Python | [Check tensor's dim order ambiguity in IR verifier](https://github.com/pytorch/executorch/issues/9942) | 10 |
-| pytorch/pytorch | Python | [Expand Tag Set: views & reductions](https://github.com/pytorch/pytorch/issues/129020) | 10 |
-| huggingface/datasets | Python | [Identical keywords in build_kwargs and config_kwargs lead to TypeError in load_dataset_builder()](https://github.com/huggingface/datasets/issues/4910) | 10 |
-| huggingface/datasets | Python | [WMT21 & WMT22](https://github.com/huggingface/datasets/issues/4709) | 10 |
-| huggingface/lighteval | Python | [[EVAL] Add TUMLU benchmark](https://github.com/huggingface/lighteval/issues/577) | 10 |
-| canonical/open-documentation-academy | Python | [MicroCeph: Replace :doc: with :ref: targets for internal cross-reference links (2)](https://github.com/canonical/open-documentation-academy/issues/277) | 10 |
-| pytorch/ao | Python | [Named Symbol not found (torchchat #1298)](https://github.com/pytorch/ao/issues/1110) | 11 |
-| pytorch/ao | Python | [[MPS] torchao low-bit-precision optim does not expose 'backend' argument to torch.compile](https://github.com/pytorch/ao/issues/955) | 11 |
-| pytorch/pytorch | Python | [foreach_map enhancements](https://github.com/pytorch/pytorch/issues/158968) | 11 |
-| pytorch/pytorch | Python | [Docs are little bit outdated for torch logs](https://github.com/pytorch/pytorch/issues/137285) | 11 |
-| pytorch/pytorch | Python | [bmm, topk, cholesky, linalg.norm, max with out variants set causing recompilations in torch.compile](https://github.com/pytorch/pytorch/issues/135859) | 11 |
+| tensorflow/probability | Jupyter Notebook | [Feature Request: Alternative Horseshoe Parameterization as tfp distribution](https://github.com/tensorflow/probability/issues/1465) | 3 |
+| tensorflow/probability | Jupyter Notebook | [Feature Request: Efficient Poisson Binomial PMF/CDF in tfp](https://github.com/tensorflow/probability/issues/1453) | 13 |
+| tensorflow/probability | Jupyter Notebook | [Feature Request: Add crps method to tfp.distributions](https://github.com/tensorflow/probability/issues/1340) | 1 |
+| tensorflow/probability | Jupyter Notebook | [[Feature Request] Zero-Inflated Poisson and Negative Binomial distributions](https://github.com/tensorflow/probability/issues/1134) | 13 |
+| tensorflow/probability | Jupyter Notebook | [[Feature Request] tensorflow_probability.distributions.GeneralizedGamma](https://github.com/tensorflow/probability/issues/1081) | 11 |
+| tensorflow/probability | Jupyter Notebook | [BFGS user should be able to pass parameters to the line search](https://github.com/tensorflow/probability/issues/1043) | 7 |
+| tensorflow/probability | Jupyter Notebook | [Support for SeparableConv1DFlipout](https://github.com/tensorflow/probability/issues/745) | 2 |
+| tensorflow/probability | Jupyter Notebook | [NotImplementedError: mean is not implemented: Categorical](https://github.com/tensorflow/probability/issues/685) | 2 |
+| tensorflow/probability | Jupyter Notebook | [A question about target_log_prob_fn](https://github.com/tensorflow/probability/issues/611) | 4 |
+| tensorflow/probability | Jupyter Notebook | [Any plans to update the examples to TensorFlow 2?](https://github.com/tensorflow/probability/issues/607) | 8 |
+| tensorflow/probability | Jupyter Notebook | [Please add example on NUTS sampling from posterior for Bayesian Logistic Regression](https://github.com/tensorflow/probability/issues/588) | 3 |
+| tensorflow/probability | Jupyter Notebook | [Laplace approximation](https://github.com/tensorflow/probability/issues/570) | 5 |
+| tensorflow/probability | Jupyter Notebook | [Feature request: Tweedie distribution](https://github.com/tensorflow/probability/issues/529) | 3 |
+| tensorflow/probability | Jupyter Notebook | [CholeskyWishart distribution](https://github.com/tensorflow/probability/issues/527) | 3 |
+| tensorflow/probability | Jupyter Notebook | [Always-on dropout layer](https://github.com/tensorflow/probability/issues/420) | 2 |
+| tensorflow/probability | Jupyter Notebook | [Keyword argument overload (?) in tfb.real_nvp_default_template](https://github.com/tensorflow/probability/issues/350) | 1 |
+| tensorflow/probability | Jupyter Notebook | [providing sample weights to glm.fit() and glm.fit.sparse()](https://github.com/tensorflow/probability/issues/252) | 0 |
+| tensorflow/probability | Jupyter Notebook | [Missing Inverse Wishart - redefine Wishart?](https://github.com/tensorflow/probability/issues/247) | 5 |
+| tensorflow/probability | Jupyter Notebook | [Provide a resimulation Metropolis TransitionKernel](https://github.com/tensorflow/probability/issues/218) | 4 |
+| tensorflow/probability | Jupyter Notebook | [Sample different weights for examples within a  batch](https://github.com/tensorflow/probability/issues/153) | 9 |
+| tensorflow/probability | Jupyter Notebook | [Tutorial on Variational Inference](https://github.com/tensorflow/probability/issues/149) | 6 |
+| tensorflow/probability | Jupyter Notebook | [Categorical features in logistic regression](https://github.com/tensorflow/probability/issues/94) | 5 |
+| tensorflow/probability | Jupyter Notebook | [DenseFlipOut layer](https://github.com/tensorflow/probability/issues/88) | 2 |
+| tensorflow/probability | Jupyter Notebook | [improve text and visuals in Bayesian Gaussian mixture model tutorial](https://github.com/tensorflow/probability/issues/74) | 3 |
+| tensorflow/probability | Jupyter Notebook | [Categorical autoregressive distribution with LSTM example/tutorial](https://github.com/tensorflow/probability/issues/73) | 2 |
+| tensorflow/probability | Jupyter Notebook | [Stochastic block model example/tutorial](https://github.com/tensorflow/probability/issues/71) | 5 |
+| tensorflow/probability | Jupyter Notebook | [Sigmoid belief network example/tutorial](https://github.com/tensorflow/probability/issues/70) | 0 |
+| tensorflow/probability | Jupyter Notebook | [Item response theory model example/tutorial](https://github.com/tensorflow/probability/issues/69) | 1 |
+| tensorflow/probability | Jupyter Notebook | [Logistic factorial analysis example/tutorial](https://github.com/tensorflow/probability/issues/68) | 0 |
+| tensorflow/probability | Jupyter Notebook | [Bayesian neural network tutorial](https://github.com/tensorflow/probability/issues/66) | 1 |
 | tensorflow/quantum | Python | [[Performance] Boost tfq.convert_to_tensor speed](https://github.com/tensorflow/quantum/issues/336) | 11 |
-| huggingface/diffusers | Python | [[Flux ControlNet] Add support for de-distilled models with CFG](https://github.com/huggingface/diffusers/issues/9635) | 11 |
-| django/djangoproject.com | Python | [Add link to 'Stable' doc version in the Warning Alert on top](https://github.com/django/djangoproject.com/issues/2094) | 11 |
-| pytorch/ao | Python | [Update documents addressing AQT workflow](https://github.com/pytorch/ao/issues/3637) | 12 |
-| pytorch/pytorch | Python | [[dynamo] [dynamic] `torch.combinations` throws RuntimeError when `(backend=aot_eager, dynamic=True)`](https://github.com/pytorch/pytorch/issues/163759) | 12 |
-| pytorch/pytorch | Python | [Logging when executing fx.Interpreter](https://github.com/pytorch/pytorch/issues/117351) | 12 |
-| django/djangoproject.com | Python | [Make right sidebar independent from main content](https://github.com/django/djangoproject.com/issues/1366) | 12 |
-| pytorch/pytorch | Python | [torch.compile regression 2.9.1: Triton kernel name '_Runner__kernel_name_0' is not defined](https://github.com/pytorch/pytorch/issues/170398) | 13 |
-| pytorch/pytorch | Python | [[Feature request] `torch.export` .save/.load could support `safetensors` and/or `weights_only=True`](https://github.com/pytorch/pytorch/issues/153410) | 13 |
-| django/djangoproject.com | Python | [New content: Accessibility statement](https://github.com/django/djangoproject.com/issues/1430) | 13 |
-| pytorch/pytorch | Python | [Make tlparse able to show a summary of distinct graph breaks](https://github.com/pytorch/pytorch/issues/153669) | 14 |
-| huggingface/diffusers | Python | [[Pipeline] AnimateDiff + SparseControl + ControlNet](https://github.com/huggingface/diffusers/issues/9329) | 14 |
-| canonical/open-documentation-academy | Python | [Charmed Ceph: Replace gerunds with imperatives](https://github.com/canonical/open-documentation-academy/issues/278) | 14 |
-| django/djangoproject.com | Python | [Improve 404 page](https://github.com/django/djangoproject.com/issues/1347) | 14 |
-| canonical/open-documentation-academy | Python | [Charmed Ceph: Stylistic inconsistencies in the how-to index](https://github.com/canonical/open-documentation-academy/issues/280) | 15 |
-| huggingface/datasets | Python | [Consider using "Sequence" instead of "List"](https://github.com/huggingface/datasets/issues/5354) | 16 |
-| canonical/cloud-init | Python | [[feature] support key by url in apt configure module](https://github.com/canonical/cloud-init/issues/4076) | 16 |
-| pytorch/ao | Python | [Replace flash_4 with FlexAttention](https://github.com/pytorch/ao/issues/639) | 17 |
-| pytorch/pytorch | Python | [Supporting custom attributes with `__torch_function__` tensor subclasses](https://github.com/pytorch/pytorch/issues/117806) | 17 |
-| django/djangoproject.com | Python | [Localize the fundraising app](https://github.com/django/djangoproject.com/issues/377) | 17 |
-| pytorch/ao | Python | [Add codebook (look up table based) quantization flow in torchao](https://github.com/pytorch/ao/issues/1195) | 18 |
-| pytorch/audio | Python | [Add Stereo to Mono Convertions](https://github.com/pytorch/audio/issues/877) | 18 |
-| pytorch/executorch | Python | [[Request impl] Devtool end-to-end tests](https://github.com/pytorch/executorch/issues/9778) | 18 |
-| pytorch/pytorch | Python | [Obscure error: Expected a value of type 'List[int]' for argument 'sizes' but instead found type 'immutable_list'](https://github.com/pytorch/pytorch/issues/122129) | 18 |
-| huggingface/datasets | Python | [Return the name of the currently loaded file in the load_dataset function.](https://github.com/huggingface/datasets/issues/5806) | 18 |
-| huggingface/huggingface_hub | Python | [[Community event] Translate documentation to your own langage](https://github.com/huggingface/huggingface_hub/issues/1700) | 18 |
-| huggingface/lerobot | Python | [Make policies compatible with torch.compile](https://github.com/huggingface/lerobot/issues/2061) | 18 |
-| canonical/open-documentation-academy | Python | [Ubuntu Core: replace Markdown links with MyST references](https://github.com/canonical/open-documentation-academy/issues/243) | 21 |
-| huggingface/diffusers | Python | [Expanded init fields in StableDiffusionPipeline cause incompatibilities with many/most inherited pipelines](https://github.com/huggingface/diffusers/issues/6969) | 22 |
-| huggingface/optimum | Python | [Community contribution - `BetterTransformer` integration for more models!](https://github.com/huggingface/optimum/issues/488) | 26 |
-| canonical/open-documentation-academy | Python | [Ubuntu Server: building up the glossary](https://github.com/canonical/open-documentation-academy/issues/166) | 29 |
-| pytorch/ignite | Python | [🥇 Everyone is welcome to contribute 💯 ](https://github.com/pytorch/ignite/issues/2026) | 40 |
-| huggingface/peft | Python | [Comparison of Different Fine-Tuning Techniques for Conversational AI](https://github.com/huggingface/peft/issues/2310) | 56 |
-| huggingface/ratchet | Rust | [Reduce dependencies! 🗡️](https://github.com/huggingface/ratchet/issues/170) | 0 |
-| decentraland/godot-explorer | Rust | [[Bug]: Interaction Feedback Doesn't Trigger when holding one Control (E.g Joystick)](https://github.com/decentraland/godot-explorer/issues/1170) | 0 |
-| canonical/source-wand | Rust | [[Feature] Add repositories to Go dependencies](https://github.com/canonical/source-wand/issues/12) | 1 |
-| tensorflow/rust | Rust | [Add Scope::with_kernel_label and with_xla_cluster](https://github.com/tensorflow/rust/issues/288) | 3 |
 | tensorflow/rust | Rust | [Add OpArgDef::default_value and allowed_values](https://github.com/tensorflow/rust/issues/290) | 7 |
+| tensorflow/rust | Rust | [Add Scope::with_kernel_label and with_xla_cluster](https://github.com/tensorflow/rust/issues/288) | 3 |
+| tensorflow/similarity | Python | [Implement SwAV for self-supervised learning](https://github.com/tensorflow/similarity/issues/208) | 7 |
+| tensorflow/similarity | Python | [Add a ranking example](https://github.com/tensorflow/similarity/issues/199) | 3 |
+| tensorflow/similarity | Python | [Implement multi-siam for segmentation](https://github.com/tensorflow/similarity/issues/179) | 5 |
+| tensorflow/similarity | Python | [Lifted Structured loss](https://github.com/tensorflow/similarity/issues/102) | 9 |
+| tensorflow/similarity | Python | [Create a colab for single shot to demonstrate how augmenters works](https://github.com/tensorflow/similarity/issues/74) | 6 |
+| tensorflow/swift | Jupyter Notebook | [Installation verification tool](https://github.com/tensorflow/swift/issues/479) | 3 |
+| tensorflow/swift-apis | Swift | [[summary] Better formatting](https://github.com/tensorflow/swift-apis/issues/1075) | 0 |
+| tensorflow/swift-apis | Swift | [Lift Tensor.dimensionGathering() out of swift-models and into swift-apis](https://github.com/tensorflow/swift-apis/issues/1058) | 0 |
+| tensorflow/swift-apis | Swift | [some mutating tensor operations are not @differentiable](https://github.com/tensorflow/swift-apis/issues/1048) | 7 |
+| tensorflow/swift-apis | Swift | [Support Advanced Layers](https://github.com/tensorflow/swift-apis/issues/685) | 8 |
+| tensorflow/swift-apis | Swift | [Investigate size/performance tradeoffs for `-sil-inline-generics` and `-sil-partial-specialization`](https://github.com/tensorflow/swift-apis/issues/628) | 0 |
+| tensorflow/swift-apis | Swift | [Add preconditions](https://github.com/tensorflow/swift-apis/issues/517) | 10 |
+| tensorflow/swift-apis | Swift | [Swifty API discovery via '@available' on raw APIs.](https://github.com/tensorflow/swift-apis/issues/483) | 8 |
+| tensorflow/swift-apis | Swift | [Add derivative tests for layers](https://github.com/tensorflow/swift-apis/issues/402) | 7 |
+| tensorflow/swift-apis | Swift | [Update doc comments on non-mutating API to use proper wording.](https://github.com/tensorflow/swift-apis/issues/160) | 0 |
+| tensorflow/swift-apis | Swift | [Add more optimizers and losses](https://github.com/tensorflow/swift-apis/issues/127) | 16 |
+| tensorflow/swift-apis | Swift | [Adding Test Cases for Layers in Layer.swift file](https://github.com/tensorflow/swift-apis/issues/77) | 7 |
+| tensorflow/swift-apis | Swift | [Recursive Neural Networks (structured data/trees)](https://github.com/tensorflow/swift-apis/issues/68) | 3 |
+| tensorflow/swift-apis | Swift | [Implement Recurrent Layers](https://github.com/tensorflow/swift-apis/issues/52) | 5 |
+| tensorflow/swift-models | Jupyter Notebook | [Better error message on unzip failure](https://github.com/tensorflow/swift-models/issues/675) | 2 |
+| tensorflow/swift-models | Jupyter Notebook | [Add logging callbacks for training statistics ](https://github.com/tensorflow/swift-models/issues/663) | 1 |
+| tensorflow/swift-models | Jupyter Notebook | [Add documentation to the Gym models to specify additional dependencies for DQN](https://github.com/tensorflow/swift-models/issues/657) | 0 |
+| tensorflow/swift-models | Jupyter Notebook | [Find a more descriptive word for `numericalized`](https://github.com/tensorflow/swift-models/issues/598) | 2 |
+| tensorflow/swift-models | Jupyter Notebook | [Rewrite long nested `Sequential` types using `Sequential{N}` typealiases](https://github.com/tensorflow/swift-models/issues/492) | 2 |
+| tensorflow/swift-models | Jupyter Notebook | [[BERT-CoLA]: Use common file extraction functions](https://github.com/tensorflow/swift-models/issues/489) | 0 |
+| tensorflow/swift-models | Jupyter Notebook | [[BERT-CoLA] Data source resolution](https://github.com/tensorflow/swift-models/issues/488) | 2 |
+| tensorflow/swift-models | Jupyter Notebook | [Verify BERT variants](https://github.com/tensorflow/swift-models/issues/433) | 0 |
+| tensorflow/swift-models | Jupyter Notebook | [Object detection examples](https://github.com/tensorflow/swift-models/issues/149) | 2 |
+| tensorflow/swift-models | Jupyter Notebook | [Translation example](https://github.com/tensorflow/swift-models/issues/148) | 4 |
+| tensorflow/swift-models | Jupyter Notebook | [Speech to text example](https://github.com/tensorflow/swift-models/issues/147) | 7 |
+| tensorflow/swift-models | Jupyter Notebook | [UNet Example](https://github.com/tensorflow/swift-models/issues/35) | 15 |
+| tensorflow/tfjs-tsne | TypeScript | [Implement tensorToDataTexture in the GPU](https://github.com/tensorflow/tfjs-tsne/issues/10) | 0 |
+| godotengine/discourse-theme | SCSS | [Remove the "Sign Up" button from navbar](https://github.com/godotengine/discourse-theme/issues/15) | 2 |
 | godotengine/discourse-theme | SCSS | [Change default `green` to our own green for the Solved questions](https://github.com/godotengine/discourse-theme/issues/14) | 0 |
 | godotengine/discourse-theme | SCSS | [Make tag and tag count more distinct](https://github.com/godotengine/discourse-theme/issues/11) | 0 |
 | godotengine/discourse-theme | SCSS | [Categories are not rounded on mobile](https://github.com/godotengine/discourse-theme/issues/3) | 0 |
 | godotengine/discourse-theme | SCSS | [Search bar should not cover full width on mobile](https://github.com/godotengine/discourse-theme/issues/2) | 0 |
-| godotengine/discourse-theme | SCSS | [Remove the "Sign Up" button from navbar](https://github.com/godotengine/discourse-theme/issues/15) | 2 |
-| canonical/iot-field-example-snaps | Shell | [Resolve lingering TODOs in automount-actions](https://github.com/canonical/iot-field-example-snaps/issues/2) | 0 |
-| canonical/iot-field-example-snaps | Shell | [Implement test suite for automount-actions](https://github.com/canonical/iot-field-example-snaps/issues/1) | 0 |
-| canonical/charmed-kafka-snap | Shell | [Remove split controller implementation](https://github.com/canonical/charmed-kafka-snap/issues/51) | 1 |
-| canonical/charmed-mysql-snap | Shell | [Check MySQL shell version >= MySQL server version](https://github.com/canonical/charmed-mysql-snap/issues/77) | 1 |
-| canonical/microk8s-core-addons | Shell | [Extending DNS addon args ](https://github.com/canonical/microk8s-core-addons/issues/252) | 1 |
-| canonical/snapcraft-101-labs | Shell | [Repository cleanup](https://github.com/canonical/snapcraft-101-labs/issues/14) | 1 |
-| canonical/snap-vault | Shell | [Build date and commit ID missing from binary](https://github.com/canonical/snap-vault/issues/87) | 2 |
-| decentraland/land | Solidity | [docs needed](https://github.com/decentraland/land/issues/154) | 8 |
-| tensorflow/swift-apis | Swift | [[summary] Better formatting](https://github.com/tensorflow/swift-apis/issues/1075) | 0 |
-| tensorflow/swift-apis | Swift | [Lift Tensor.dimensionGathering() out of swift-models and into swift-apis](https://github.com/tensorflow/swift-apis/issues/1058) | 0 |
-| tensorflow/swift-apis | Swift | [Investigate size/performance tradeoffs for `-sil-inline-generics` and `-sil-partial-specialization`](https://github.com/tensorflow/swift-apis/issues/628) | 0 |
-| tensorflow/swift-apis | Swift | [Update doc comments on non-mutating API to use proper wording.](https://github.com/tensorflow/swift-apis/issues/160) | 0 |
-| huggingface/sam2-studio | Swift | [Model download selector](https://github.com/huggingface/sam2-studio/issues/28) | 1 |
+| godotengine/emacs-gdscript-mode | Emacs Lisp | [Rewrite gdscript-imenu to provide GDScript-specific tables](https://github.com/godotengine/emacs-gdscript-mode/issues/89) | 0 |
+| godotengine/emacs-gdscript-mode | Emacs Lisp | [Buffer does not revert or update instantly after formatting buffer](https://github.com/godotengine/emacs-gdscript-mode/issues/88) | 3 |
+| godotengine/godot | C++ | [Polygon2D's bug. disappear or don't render.](https://github.com/godotengine/godot/issues/117960) | 8 |
+| godotengine/godot | C++ | [[Godot v4.4] Gizmos exponentially increasing Draw Calls and Objects when turned on](https://github.com/godotengine/godot/issues/103676) | 24 |
+| godotengine/godot | C++ | [You're breathtaking!](https://github.com/godotengine/godot/issues/100000) | 34 |
+| godotengine/godot | C++ | [[TRACKER] Unit tests to add or improve](https://github.com/godotengine/godot/issues/43440) | 250 |
+| godotengine/godot-asset-library | PHP | [Sanitize inputs for Asset data/fields, like URLs](https://github.com/godotengine/godot-asset-library/issues/204) | 5 |
+| godotengine/godot-asset-library | PHP | [A way to cancel edit requests](https://github.com/godotengine/godot-asset-library/issues/149) | 3 |
+| godotengine/godot-asset-library | PHP | [Categories need a description (tooltip?) when hovered/selected](https://github.com/godotengine/godot-asset-library/issues/74) | 1 |
+| godotengine/godot-asset-library | PHP | [keep the content of the submition form when its not validated, or try some ajax realtime pre-validation](https://github.com/godotengine/godot-asset-library/issues/61) | 1 |
+| godotengine/godot-benchmarks | GDScript | [[Call to Action] Benchmarks for the benchmark server](https://github.com/godotengine/godot-benchmarks/issues/36) | 5 |
+| godotengine/godot-benchmarks | GDScript | [[TRACKER] Benchmarks to create](https://github.com/godotengine/godot-benchmarks/issues/11) | 11 |
+| godotengine/godot-blender-exporter | Python | [Blender object with negative scale](https://github.com/godotengine/godot-blender-exporter/issues/24) | 3 |
+| godotengine/godot-docs | reStructuredText | [Object.get_meta & has_meta doc mentions is_valid_identifier but deprecated (prefer is_valid_ascii_identifier)](https://github.com/godotengine/godot-docs/issues/11870) | 0 |
+| godotengine/godot-docs | reStructuredText | [PhysicsDirectSpaceState2D.get_rest_info claims not to use query motion but it does](https://github.com/godotengine/godot-docs/issues/10609) | 4 |
+| godotengine/godot-docs | reStructuredText | [Viewport "use_hdr_2d" documentation point unclear](https://github.com/godotengine/godot-docs/issues/10044) | 2 |
+| godotengine/godot-docs | reStructuredText | [Parallax2D property descriptions do not specify units](https://github.com/godotengine/godot-docs/issues/9715) | 1 |
+| godotengine/godot-docs | reStructuredText | [Control class page doesn't mention ".release_focus()" in intro](https://github.com/godotengine/godot-docs/issues/9452) | 4 |
+| godotengine/godot-docs | reStructuredText | [Add C# examples for custom BBCode](https://github.com/godotengine/godot-docs/issues/9334) | 0 |
+| godotengine/godot-docs | reStructuredText | [WorkerThreadPool docs do not specify how Thread count is set](https://github.com/godotengine/godot-docs/issues/8937) | 4 |
+| godotengine/godot-docs | reStructuredText | [make_canvas_position_local](https://github.com/godotengine/godot-docs/issues/8313) | 1 |
+| godotengine/godot-docs | reStructuredText | [Inconsistent code example between PhysicsShapeQueryParameters3D and PhysicsServer3D](https://github.com/godotengine/godot-docs/issues/8305) | 1 |
+| godotengine/godot-docs | reStructuredText | [Curve2D.get_closest_point() incorrectly documented](https://github.com/godotengine/godot-docs/issues/5894) | 1 |
+| godotengine/godot-docs | reStructuredText | [Physics2DDirectSpaceState does not specify local or global coordinates](https://github.com/godotengine/godot-docs/issues/3299) | 2 |
+| huggingface/accelerate | Python | [Deadlock when running multi tasks](https://github.com/huggingface/accelerate/issues/3814) | 1 |
+| huggingface/accelerate | Python | [[Community Contributions] examples on distributed inference using 🤗 Accelerate](https://github.com/huggingface/accelerate/issues/3078) | 4 |
+| huggingface/accelerate | Python | [Barebones dataloader to allow for any type of iterable dataloader-like object to be used. Should just handle device placement](https://github.com/huggingface/accelerate/issues/2975) | 5 |
+| huggingface/agents-course | MDX | [Improve diagrams in unit 2.1](https://github.com/huggingface/agents-course/issues/233) | 6 |
+| huggingface/awesome-huggingface | Other | [[hacktoberfest] Hugging Face Collections Hacktoberfest challenge](https://github.com/huggingface/awesome-huggingface/issues/28) | 0 |
 | huggingface/chat-macOS | Swift | [[Feature Request] System Prompt Support](https://github.com/huggingface/chat-macOS/issues/35) | 2 |
-| huggingface/chat-macOS | Swift | [Asking "what time is it?" will always return the local time of Paris, regardless of your location (⌘R+)](https://github.com/huggingface/chat-macOS/issues/7) | 2 |
-| tensorflow/swift-apis | Swift | [Recursive Neural Networks (structured data/trees)](https://github.com/tensorflow/swift-apis/issues/68) | 3 |
-| tensorflow/swift-apis | Swift | [Implement Recurrent Layers](https://github.com/tensorflow/swift-apis/issues/52) | 5 |
 | huggingface/chat-macOS | Swift | [Add custom LLM API ](https://github.com/huggingface/chat-macOS/issues/18) | 5 |
-| tensorflow/swift-apis | Swift | [some mutating tensor operations are not @differentiable](https://github.com/tensorflow/swift-apis/issues/1048) | 7 |
-| tensorflow/swift-apis | Swift | [Add derivative tests for layers](https://github.com/tensorflow/swift-apis/issues/402) | 7 |
-| tensorflow/swift-apis | Swift | [Adding Test Cases for Layers in Layer.swift file](https://github.com/tensorflow/swift-apis/issues/77) | 7 |
-| tensorflow/swift-apis | Swift | [Support Advanced Layers](https://github.com/tensorflow/swift-apis/issues/685) | 8 |
-| tensorflow/swift-apis | Swift | [Swifty API discovery via '@available' on raw APIs.](https://github.com/tensorflow/swift-apis/issues/483) | 8 |
-| tensorflow/swift-apis | Swift | [Add preconditions](https://github.com/tensorflow/swift-apis/issues/517) | 10 |
-| tensorflow/swift-apis | Swift | [Add more optimizers and losses](https://github.com/tensorflow/swift-apis/issues/127) | 16 |
+| huggingface/chat-macOS | Swift | [Asking "what time is it?" will always return the local time of Paris, regardless of your location (⌘R+)](https://github.com/huggingface/chat-macOS/issues/7) | 2 |
+| huggingface/chat-ui | TypeScript | [Add option for users to customize search engines in settings page](https://github.com/huggingface/chat-ui/issues/1756) | 3 |
+| huggingface/chat-ui | TypeScript | [Disabling Reasoning Summary as an Env Option](https://github.com/huggingface/chat-ui/issues/1720) | 5 |
+| huggingface/chat-ui | TypeScript | [Chrome app icon on macOS](https://github.com/huggingface/chat-ui/issues/1439) | 4 |
+| huggingface/chat-ui | TypeScript | [Load past conversations using the most recent leaf to determine the visible conversation tree.](https://github.com/huggingface/chat-ui/issues/1208) | 3 |
+| huggingface/chat-ui | TypeScript | [System prompt not taken into account when web browsing.](https://github.com/huggingface/chat-ui/issues/1159) | 3 |
+| huggingface/dataset-viewer | Python | [use the `ROW_IDX_COLUMN` constant name instead of copying the value everywhere](https://github.com/huggingface/dataset-viewer/issues/2798) | 2 |
+| huggingface/dataset-viewer | Python | [Use `revision_exists` (hfh)](https://github.com/huggingface/dataset-viewer/issues/2562) | 1 |
+| huggingface/dataset-viewer | Python | [Cache/Queue metrics should not be negative](https://github.com/huggingface/dataset-viewer/issues/2495) | 4 |
+| huggingface/dataset-viewer | Python | [Use "Sign-In with HF" instead of token in admin-UI](https://github.com/huggingface/dataset-viewer/issues/2373) | 2 |
+| huggingface/dataset-viewer | Python | [Use `CONSTANT_LIST.copy` in list config fieds](https://github.com/huggingface/dataset-viewer/issues/1522) | 3 |
+| huggingface/datasets | Python | [Return the name of the currently loaded file in the load_dataset function.](https://github.com/huggingface/datasets/issues/5806) | 18 |
+| huggingface/datasets | Python | [Consider using "Sequence" instead of "List"](https://github.com/huggingface/datasets/issues/5354) | 16 |
+| huggingface/datasets | Python | [Identical keywords in build_kwargs and config_kwargs lead to TypeError in load_dataset_builder()](https://github.com/huggingface/datasets/issues/4910) | 10 |
+| huggingface/datasets | Python | [WMT21 & WMT22](https://github.com/huggingface/datasets/issues/4709) | 10 |
+| huggingface/diffusers | Python | [Do we have any script covert from hf format to orginal format?](https://github.com/huggingface/diffusers/issues/10076) | 1 |
+| huggingface/diffusers | Python | [[Flux ControlNet] Add support for de-distilled models with CFG](https://github.com/huggingface/diffusers/issues/9635) | 11 |
+| huggingface/diffusers | Python | [[Pipeline] AnimateDiff + SparseControl + ControlNet](https://github.com/huggingface/diffusers/issues/9329) | 14 |
+| huggingface/diffusers | Python | [Support multiple control nets in the `StableDiffusionControlNetXSPipeline`/`StableDiffusionXLControlNetXSPipeline`](https://github.com/huggingface/diffusers/issues/8434) | 9 |
+| huggingface/diffusers | Python | [Expanded init fields in StableDiffusionPipeline cause incompatibilities with many/most inherited pipelines](https://github.com/huggingface/diffusers/issues/6969) | 22 |
+| huggingface/diffusers | Python | [Make `FlaxLMSDiscreteScheduler` jittable](https://github.com/huggingface/diffusers/issues/2180) | 8 |
+| huggingface/huggingface-gemma-recipes | Jupyter Notebook | [📣 Call for contributions!](https://github.com/huggingface/huggingface-gemma-recipes/issues/4) | 11 |
+| huggingface/huggingface-llama-recipes | Jupyter Notebook | [Call for contributions](https://github.com/huggingface/huggingface-llama-recipes/issues/43) | 20 |
+| huggingface/huggingface.js | TypeScript | [Maximize button not working properly on Hosted inference API block](https://github.com/huggingface/huggingface.js/issues/335) | 2 |
+| huggingface/huggingface.js | TypeScript | [Tracking integration for Video Classification](https://github.com/huggingface/huggingface.js/issues/332) | 8 |
+| huggingface/huggingface_hub | Python | [[Community event] Translate documentation to your own langage](https://github.com/huggingface/huggingface_hub/issues/1700) | 18 |
+| huggingface/lerobot | Python | [Question regarding downsampling and resizing dataset](https://github.com/huggingface/lerobot/issues/2124) | 1 |
+| huggingface/lerobot | Python | [Select the VLM backbone for SmolVLA](https://github.com/huggingface/lerobot/issues/2104) | 8 |
+| huggingface/lerobot | Python | [How can I change the task name of already recorded episodes?](https://github.com/huggingface/lerobot/issues/2096) | 4 |
+| huggingface/lerobot | Python | [Make policies compatible with torch.compile](https://github.com/huggingface/lerobot/issues/2061) | 18 |
+| huggingface/lerobot | Python | [Distributed v2.1 -> v3.0 conversion](https://github.com/huggingface/lerobot/issues/1998) | 6 |
+| huggingface/lerobot | Python | [Finetune smolvla with vision encoder](https://github.com/huggingface/lerobot/issues/1774) | 2 |
+| huggingface/lerobot | Python | [Ensure the utilities module passes MyPy type checks](https://github.com/huggingface/lerobot/issues/1727) | 4 |
+| huggingface/lerobot | Python | [Ensure the teleoperators module passes MyPy type checks](https://github.com/huggingface/lerobot/issues/1726) | 1 |
+| huggingface/lighteval | Python | [[EVAL] Long Horizon Execution](https://github.com/huggingface/lighteval/issues/1056) | 7 |
+| huggingface/lighteval | Python | [[EVAL] Add kyrgyzLLM benchmark](https://github.com/huggingface/lighteval/issues/1036) | 1 |
+| huggingface/lighteval | Python | [[FT] showing count in Markdown summary table](https://github.com/huggingface/lighteval/issues/804) | 3 |
+| huggingface/lighteval | Python | [[FT]  Add tests for nanotron](https://github.com/huggingface/lighteval/issues/765) | 3 |
+| huggingface/lighteval | Python | [[BUG] custom model docs don't run: missing imports](https://github.com/huggingface/lighteval/issues/760) | 5 |
+| huggingface/lighteval | Python | [[FT] Manage script and language in the Language enum](https://github.com/huggingface/lighteval/issues/745) | 1 |
+| huggingface/lighteval | Python | [[BUG]  Optimize tokenization](https://github.com/huggingface/lighteval/issues/732) | 0 |
+| huggingface/lighteval | Python | [[FT]  Add tests for `VLLMModel` base methods](https://github.com/huggingface/lighteval/issues/724) | 0 |
+| huggingface/lighteval | Python | [Call for contributions: Translate lighteval's doc into Chinese](https://github.com/huggingface/lighteval/issues/716) | 2 |
+| huggingface/lighteval | Python | [[EVAL] Adding PHARE](https://github.com/huggingface/lighteval/issues/696) | 8 |
+| huggingface/lighteval | Python | [[FT] Improve Documentation and Examples](https://github.com/huggingface/lighteval/issues/682) | 6 |
+| huggingface/lighteval | Python | [[FT] Build in a way to specify specific IDs/Lines in Dataset to use as few-shot examples in the same split](https://github.com/huggingface/lighteval/issues/634) | 0 |
+| huggingface/lighteval | Python | [[EVAL] Big-Bench Extra Hard (BBEH)](https://github.com/huggingface/lighteval/issues/600) | 3 |
+| huggingface/lighteval | Python | [[EVAL] Add TUMLU benchmark](https://github.com/huggingface/lighteval/issues/577) | 10 |
+| huggingface/lighteval | Python | [[FT] LiteLLM concurrency parameters hard-coded](https://github.com/huggingface/lighteval/issues/567) | 1 |
+| huggingface/lighteval | Python | [[EVAL]: Add more African Benchmarks](https://github.com/huggingface/lighteval/issues/373) | 4 |
+| huggingface/lighteval | Python | [Append revision to filepath in `--output_dir`?](https://github.com/huggingface/lighteval/issues/56) | 5 |
+| huggingface/nanotron | Python | [Avoid nested `InheritFromOtherOptimizer`](https://github.com/huggingface/nanotron/issues/267) | 5 |
+| huggingface/nanotron | Python | [[Bug] Missing `_is_using_mup` when resume checkpoint](https://github.com/huggingface/nanotron/issues/198) | 5 |
+| huggingface/nanotron | Python | [Add Debug utility to be able to preview first samples used for training](https://github.com/huggingface/nanotron/issues/184) | 1 |
+| huggingface/nanotron | Python | [We don't save checkpoint after training ends](https://github.com/huggingface/nanotron/issues/163) | 1 |
+| huggingface/nanotron | Python | [FEAT: Support 1.58-bit LLMs training](https://github.com/huggingface/nanotron/issues/114) | 1 |
+| huggingface/nanotron | Python | [[Unit Test] Add unit tests for DistributedTrainer](https://github.com/huggingface/nanotron/issues/90) | 5 |
+| huggingface/nanotron | Python | [[Feature] Use CUDA event for measuring elasped time](https://github.com/huggingface/nanotron/issues/88) | 0 |
+| huggingface/nanotron | Python | [[Feature] Asyncronous Serialization](https://github.com/huggingface/nanotron/issues/87) | 2 |
+| huggingface/nanotron | Python | [[Feature] Refactor `ParallelContext.world_rank_matrix`](https://github.com/huggingface/nanotron/issues/77) | 0 |
+| huggingface/nanotron | Python | [[Feature Request] Support Data Streaming for faster training of large models](https://github.com/huggingface/nanotron/issues/45) | 2 |
+| huggingface/nanotron | Python | [[Feature Request] Add simple communications benchmarks to the repo](https://github.com/huggingface/nanotron/issues/43) | 1 |
+| huggingface/optimum | Python | [Community contribution - `BetterTransformer` integration for more models!](https://github.com/huggingface/optimum/issues/488) | 26 |
+| huggingface/optimum | Python | [Add all available ONNX models to ORTConfigManager](https://github.com/huggingface/optimum/issues/351) | 3 |
+| huggingface/optimum-benchmark | Python | [Evaluators for specific tasks](https://github.com/huggingface/optimum-benchmark/issues/34) | 5 |
+| huggingface/optimum-executorch | Python | [Add benchmarking numbers for more models](https://github.com/huggingface/optimum-executorch/issues/131) | 0 |
+| huggingface/optimum-habana | Python | [Add support for max_length in run_generation](https://github.com/huggingface/optimum-habana/issues/472) | 3 |
+| huggingface/optimum-intel | Jupyter Notebook | [Add tests which check, that required transformations are applied](https://github.com/huggingface/optimum-intel/issues/1645) | 4 |
+| huggingface/optimum-intel | Jupyter Notebook | [Fix conversion of ltx_video models in bf16 format](https://github.com/huggingface/optimum-intel/issues/1614) | 2 |
+| huggingface/peft | Python | [Comparison of Different Fine-Tuning Techniques for Conversational AI](https://github.com/huggingface/peft/issues/2310) | 56 |
+| huggingface/ratchet | Rust | [Reduce dependencies! 🗡️](https://github.com/huggingface/ratchet/issues/170) | 0 |
+| huggingface/sam2-studio | Swift | [Model download selector](https://github.com/huggingface/sam2-studio/issues/28) | 1 |
 | huggingface/sam2-studio | Swift | [Video support estimated release date?](https://github.com/huggingface/sam2-studio/issues/25) | 26 |
-| pytorch/test-infra | TypeScript | [Better highlight scheme for force merges](https://github.com/pytorch/test-infra/issues/5229) | 0 |
-| tensorflow/tfjs-tsne | TypeScript | [Implement tensorToDataTexture in the GPU](https://github.com/tensorflow/tfjs-tsne/issues/10) | 0 |
+| huggingface/sentence-transformers | Python | [Update example scripts relying on `model.fit` to use `SentenceTransformerTrainer` instead](https://github.com/huggingface/sentence-transformers/issues/3621) | 5 |
+| huggingface/sentence-transformers | Python | [Update example scripts relying on `http_get` to download from the Hugging Face Hub instead](https://github.com/huggingface/sentence-transformers/issues/3620) | 1 |
+| huggingface/transfer-learning-conv-ai | Python | [RuntimeError: shape '[-1, 2, 34]' is invalid for input of size 61710](https://github.com/huggingface/transfer-learning-conv-ai/issues/12) | 3 |
+| huggingface/transformers.js | JavaScript | [Is 'aggregation_strategy' parameter available for token classification pipeline?](https://github.com/huggingface/transformers.js/issues/633) | 2 |
+| huggingface/transformers.js | JavaScript | [[Feature request] Return offset mapping using tokenizer](https://github.com/huggingface/transformers.js/issues/425) | 2 |
+| huggingface/transformers.js | JavaScript | [[Doc request] Add an example guide of how to use it in Svelte (and deploy to HF Spaces)](https://github.com/huggingface/transformers.js/issues/171) | 7 |
+| ansible/ansible-documentation | Python | [Need explanation that modules can only import from `module_utils` within the `ansible` namespace](https://github.com/ansible/ansible-documentation/issues/3442) | 1 |
+| ansible/ansible-documentation | Python | [Prune stub files in docs/docsite](https://github.com/ansible/ansible-documentation/issues/3228) | 1 |
+| ansible/ansible-documentation | Python | [Misleading statement about "defaults" and "vars" sub-folders of roles](https://github.com/ansible/ansible-documentation/issues/2994) | 6 |
+| ansible/ansible-documentation | Python | [Link to devel in the various roadmaps](https://github.com/ansible/ansible-documentation/issues/1865) | 4 |
+| ansible/ansible-documentation | Python | [Incorporate 'shared snippets' for the collection docs into the main rst files](https://github.com/ansible/ansible-documentation/issues/1382) | 3 |
+| ansible/ansible-documentation | Python | [Link "see also" sections as recommended in the forum](https://github.com/ansible/ansible-documentation/issues/1200) | 8 |
+| ansible/ansible-jupyter-kernel | Python | [Add support for handlers](https://github.com/ansible/ansible-jupyter-kernel/issues/53) | 0 |
+| ansible/ansible-jupyter-kernel | Python | [Add a #library cell type](https://github.com/ansible/ansible-jupyter-kernel/issues/26) | 0 |
+| ansible/ansible-lint | Python | ['format' option missing from configuration file schema](https://github.com/ansible/ansible-lint/issues/4898) | 7 |
+| ansible/ansible-navigator | Python | [Switch to the use of `pathlib` where possible](https://github.com/ansible/ansible-navigator/issues/697) | 2 |
+| ansible/ansible-navigator | Python | [Allow to set ansible-runner artifacts dir ID ](https://github.com/ansible/ansible-navigator/issues/521) | 6 |
+| ansible/ansible-navigator | Python | [Many params missing change after initial = False](https://github.com/ansible/ansible-navigator/issues/423) | 1 |
 | ansible/ansible-ui | TypeScript | [EDA-Server logo is not loading correctly on the login page when eda-server is installed via eda-server-operator](https://github.com/ansible/ansible-ui/issues/3087) | 0 |
+| ansible/ansible-ui | TypeScript | [Logo not loading correctly when building UI together with backend in a single image](https://github.com/ansible/ansible-ui/issues/3086) | 2 |
+| ansible/ansible-ui | TypeScript | [When job is running, selected EE is not visible in the UI, it appears only after it finishes](https://github.com/ansible/ansible-ui/issues/3085) | 8 |
+| ansible/awx | Python | [Add option to force the user to reset its password at first login](https://github.com/ansible/awx/issues/15766) | 5 |
+| ansible/awx | Python | [Empty value in execution_environment should remove selections (ansible.controller.job_template)](https://github.com/ansible/awx/issues/14841) | 2 |
+| ansible/awx | Python | [Fix Delinea imports and import test](https://github.com/ansible/awx/issues/14703) | 3 |
+| ansible/awx | Python | [ adhoc jobs block other jobs from being processed in the queue](https://github.com/ansible/awx/issues/14645) | 5 |
+| ansible/awx | Python | [ visualizer info field ](https://github.com/ansible/awx/issues/14597) | 4 |
+| ansible/awx | Python | [Scheduled Job prompted extra_vars overwritten by JT extra_vars](https://github.com/ansible/awx/issues/14445) | 1 |
+| ansible/awx | Python | [Cleanup Job Details. Configure days retention for the particular job entities. ](https://github.com/ansible/awx/issues/14384) | 3 |
+| ansible/awx | Python | [Improve user experience of copy pasting FQDNs from jobs](https://github.com/ansible/awx/issues/14354) | 3 |
+| ansible/awx | Python | [Non descriptive error when podman is missing](https://github.com/ansible/awx/issues/14341) | 3 |
+| ansible/awx | Python | [AWX Collection Credential Delete](https://github.com/ansible/awx/issues/14209) | 6 |
+| ansible/awx | Python | [Issue label for incompliance with Ansible](https://github.com/ansible/awx/issues/13272) | 2 |
+| ansible/awx | Python | [New credentials type to provide VAULT_ADDR and VAULT_TOKEN env vars](https://github.com/ansible/awx/issues/13117) | 2 |
+| ansible/awx | Python | [all cluster nodes in development environment have the same UUID](https://github.com/ansible/awx/issues/13029) | 5 |
+| ansible/awx | Python | [Display SAML login icon for /api/login page](https://github.com/ansible/awx/issues/12905) | 8 |
+| ansible/awx | Python | [Add "nodes" to "Relaunch on" when relaunching jobs after failure - users think it relates to failed tasks and not nodes](https://github.com/ansible/awx/issues/12438) | 3 |
+| ansible/awx | Python | [Worker failed to run task awx.main.tasks.system.purge_old_stdout_files](https://github.com/ansible/awx/issues/11903) | 3 |
+| ansible/awx | Python | [Remove some of the eslint-disable comments](https://github.com/ansible/awx/issues/11707) | 4 |
+| ansible/awx | Python | [Docker install instructions do not mention how to add awx-logos](https://github.com/ansible/awx/issues/11593) | 4 |
+| ansible/awx | Python | [System Auditors can check list items](https://github.com/ansible/awx/issues/10841) | 3 |
+| ansible/awx | Python | [[ui_next] Add All/Any workflow viz indication to Workflow Viz Legend/Key](https://github.com/ansible/awx/issues/9791) | 0 |
+| ansible/awx | Python | [Inaccurate error handling on Input Group Integer fields (i.e. Org Max Hosts field)](https://github.com/ansible/awx/issues/8556) | 1 |
+| ansible/awx | Python | [Expose the value of "Execution Node" as a variable when running a job from Ansible Tower.](https://github.com/ansible/awx/issues/8122) | 2 |
+| ansible/awx | Python | [Show more host information in host filter lookup list ](https://github.com/ansible/awx/issues/7853) | 3 |
+| ansible/awx | Python | [Inconsistent capitalization across ui-next ](https://github.com/ansible/awx/issues/7037) | 3 |
+| ansible/awx | Python | ["Playbook not found for project" error when the playbook exist but is invalid ](https://github.com/ansible/awx/issues/6842) | 2 |
+| ansible/awx | Python | [Jobs canceled before starting should not show a "finished" time](https://github.com/ansible/awx/issues/3988) | 2 |
+| ansible/awx | Python | [Make Info Metrics more easy to query](https://github.com/ansible/awx/issues/3781) | 2 |
+| ansible/awx | Python | [weekly dashboard view does not have sufficient granularity](https://github.com/ansible/awx/issues/3060) | 2 |
+| ansible/awx | Python | [User auth field not documented in OPTIONS](https://github.com/ansible/awx/issues/2301) | 3 |
+| ansible/awx | Python | [RFE: Send real client remote address in TACACS+ authentication packet](https://github.com/ansible/awx/issues/1797) | 1 |
+| ansible/awx-operator | Jinja | [Add multi-arch build target](https://github.com/ansible/awx-operator/issues/1680) | 1 |
+| ansible/awx-operator | Jinja | [annotations not applied to postgres statefulset](https://github.com/ansible/awx-operator/issues/1624) | 2 |
+| ansible/awx-operator | Jinja | [Inflated Total Host Count on Dashboard when Using Constructed Inventory with Existing Inventories](https://github.com/ansible/awx-operator/issues/1459) | 2 |
+| ansible/awx-operator | Jinja | [Extend README with external logging examples](https://github.com/ansible/awx-operator/issues/1086) | 2 |
+| ansible/awx-operator | Jinja | [Inability to overwrite namespace when using awx-operator chart](https://github.com/ansible/awx-operator/issues/999) | 3 |
+| ansible/awx-operator | Jinja | [Password set via UI gets overwritten by initialize_django playbook](https://github.com/ansible/awx-operator/issues/869) | 5 |
+| ansible/dispatcherd | Python | [Enforce UUID format, add "origin" information in message data](https://github.com/ansible/dispatcherd/issues/96) | 0 |
+| ansible/django-ansible-base | Python | [`ansible_base.lib.utils.models.diff` takes unused `sanitize_encrypted` param and has outdated return docstring](https://github.com/ansible/django-ansible-base/issues/688) | 0 |
+| ansible/django-ansible-base | Python | [Several unordered querysets](https://github.com/ansible/django-ansible-base/issues/178) | 1 |
+| ansible/galaxy_collection | Jinja | [Replace order of roles](https://github.com/ansible/galaxy_collection/issues/396) | 0 |
+| ansible/product-demos | Jinja | [Add teardown template/workflow for "Deploy Cloud Stack in AWS" workflow](https://github.com/ansible/product-demos/issues/192) | 1 |
+| ansible/pylibssh | Cython | [[TODO] Ensure release builds don't include debug symbols](https://github.com/ansible/pylibssh/issues/767) | 0 |
+| ansible/receptor | Go | [quality of life -- order work list output based on most recent work units](https://github.com/ansible/receptor/issues/425) | 2 |
+| ansible/receptor | Go | [append conntype string representation in status output](https://github.com/ansible/receptor/issues/423) | 0 |
+| ansible/receptor | Go | [add work status command to receptorctl](https://github.com/ansible/receptor/issues/374) | 1 |
+| ansible/terraform-provider-ansible | Go | [ansible_playbook_run doesn't accept variable](https://github.com/ansible/terraform-provider-ansible/issues/154) | 1 |
+| ansible/vscode-ansible | TypeScript | [Option to completely disable autocomplete](https://github.com/ansible/vscode-ansible/issues/837) | 3 |
 | ansible/vscode-ansible | TypeScript | [Add option to prefix all shell commands the plugin executes](https://github.com/ansible/vscode-ansible/issues/429) | 0 |
 | decentraland/account | TypeScript | [The withdrawal from Polygon modal styles are broken](https://github.com/decentraland/account/issues/277) | 0 |
 | decentraland/account | TypeScript | [Change alias is shown when the user has no names](https://github.com/decentraland/account/issues/264) | 0 |
@@ -729,12 +522,15 @@ If you are wondering where to begin in the  journey contributing to open-source 
 | decentraland/asset-packs | TypeScript | [Fix hide image action](https://github.com/decentraland/asset-packs/issues/170) | 0 |
 | decentraland/atlas-server | TypeScript | [Add a redirect or message with a link to the documentation at /](https://github.com/decentraland/atlas-server/issues/3) | 0 |
 | decentraland/auth | TypeScript | [Migrate getAnalytics to useAnalytics Hook](https://github.com/decentraland/auth/issues/198) | 0 |
+| decentraland/builder | TypeScript | [Add a search bar to NAMEs list](https://github.com/decentraland/builder/issues/3330) | 1 |
 | decentraland/builder | TypeScript | [Item badges have broken styles in the Third Party Collections detail page](https://github.com/decentraland/builder/issues/2733) | 0 |
 | decentraland/builder | TypeScript | [Wrong items left to curate for third parties without items to curate](https://github.com/decentraland/builder/issues/2573) | 0 |
 | decentraland/builder | TypeScript | [Third party checkboxes being grayed out but functional](https://github.com/decentraland/builder/issues/2572) | 0 |
 | decentraland/builder | TypeScript | [Avoid letting the user click the Enable collection button if the enabling process is pending](https://github.com/decentraland/builder/issues/2489) | 0 |
 | decentraland/builder | TypeScript | [I can sign the approve collection transaction and close the modal a few seconds after](https://github.com/decentraland/builder/issues/2488) | 0 |
 | decentraland/builder | TypeScript | [[Names] Show error messages when setting a name as an alias or a link fails](https://github.com/decentraland/builder/issues/2455) | 0 |
+| decentraland/builder | TypeScript | [Create auto-assign button on mint items from collection modal](https://github.com/decentraland/builder/issues/2442) | 1 |
+| decentraland/builder | TypeScript | [Add +- buttons to number input in mint items from collection](https://github.com/decentraland/builder/issues/2443) | 1 |
 | decentraland/builder | TypeScript | [The Editor pagination component redirects to the wrong page](https://github.com/decentraland/builder/issues/2410) | 0 |
 | decentraland/builder | TypeScript | [Make the Catalyst deployment of non third party wearables queued](https://github.com/decentraland/builder/issues/2389) | 0 |
 | decentraland/builder | TypeScript | [Add tests for ens module sagas ](https://github.com/decentraland/builder/issues/2274) | 0 |
@@ -746,6 +542,7 @@ If you are wondering where to begin in the  journey contributing to open-source 
 | decentraland/builder | TypeScript | [Closing the Metamask window when signing the TP approval doesn't show an error](https://github.com/decentraland/builder/issues/1923) | 0 |
 | decentraland/builder | TypeScript | [Render the Merkle Tree root in the approval flow modal](https://github.com/decentraland/builder/issues/1865) | 0 |
 | decentraland/builder | TypeScript | [Use the builder client to fetch the approval data](https://github.com/decentraland/builder/issues/1855) | 0 |
+| decentraland/builder | TypeScript | [Add link to documentation in the id field when creating TP collections](https://github.com/decentraland/builder/issues/1844) | 1 |
 | decentraland/builder | TypeScript | [Fix disabled Dropdown Items not showing Popup component](https://github.com/decentraland/builder/issues/1810) | 0 |
 | decentraland/builder | TypeScript | [Update TAC for publishing wearables](https://github.com/decentraland/builder/issues/1789) | 0 |
 | decentraland/builder | TypeScript | [Add a search bar to the /collections list](https://github.com/decentraland/builder/issues/1742) | 0 |
@@ -753,80 +550,283 @@ If you are wondering where to begin in the  journey contributing to open-source 
 | decentraland/builder | TypeScript | [Multiple mints set invalid values](https://github.com/decentraland/builder/issues/1690) | 0 |
 | decentraland/builder | TypeScript | [Show progress bar on Upload Files modal](https://github.com/decentraland/builder/issues/1614) | 0 |
 | decentraland/builder | TypeScript | [Broken link on publish collection Content Policy](https://github.com/decentraland/builder/issues/1588) | 0 |
+| decentraland/builder | TypeScript | [Assigned Parcel Name dissapears after changing language](https://github.com/decentraland/builder/issues/1540) | 1 |
 | decentraland/builder | TypeScript | [Add a tooltip to the publish button to explain the user what is needed to publish a collection](https://github.com/decentraland/builder/issues/1485) | 0 |
 | decentraland/builder-server | TypeScript | [Stop accepting isPublished, isApproved, minters and managers properties](https://github.com/decentraland/builder-server/issues/553) | 0 |
 | decentraland/builder-server | TypeScript | [Stop accepting the id field for Collections on Collections creation](https://github.com/decentraland/builder-server/issues/552) | 0 |
 | decentraland/builder-server | TypeScript | [Replace isomorphic-fetch with node-fetch](https://github.com/decentraland/builder-server/issues/434) | 0 |
 | decentraland/catalyst-client | TypeScript | [Add missing endpoints to Lambdas Client (review the other clients) to keep it up to date](https://github.com/decentraland/catalyst-client/issues/479) | 0 |
 | decentraland/creator-hub | TypeScript | [Name tooltip too high when searching](https://github.com/decentraland/creator-hub/issues/1010) | 0 |
+| decentraland/creator-hub | TypeScript | [Need to click twice on "Create Scene" button to create the scene](https://github.com/decentraland/creator-hub/issues/832) | 1 |
 | decentraland/creator-hub | TypeScript | [Option to rename folder](https://github.com/decentraland/creator-hub/issues/791) | 0 |
 | decentraland/creator-hub | TypeScript | [Missing owner property on Worlds deployment](https://github.com/decentraland/creator-hub/issues/774) | 0 |
 | decentraland/creator-hub | TypeScript | [Change selected item highlight effect](https://github.com/decentraland/creator-hub/issues/768) | 0 |
+| decentraland/creator-hub | TypeScript | [Duplicated items appear at the bottom of the list](https://github.com/decentraland/creator-hub/issues/595) | 1 |
 | decentraland/creator-hub | TypeScript | [Reorder scene list on landing](https://github.com/decentraland/creator-hub/issues/437) | 0 |
 | decentraland/creator-hub | TypeScript | [Separate search results by category](https://github.com/decentraland/creator-hub/issues/430) | 0 |
 | decentraland/creator-hub | TypeScript | [Row spacing in asset packs stretches in ugly way](https://github.com/decentraland/creator-hub/issues/429) | 0 |
 | decentraland/creator-hub | TypeScript | [Publish status/history improvements](https://github.com/decentraland/creator-hub/issues/338) | 0 |
 | decentraland/creator-hub | TypeScript | [Field width wide as longest option, not current value](https://github.com/decentraland/creator-hub/issues/200) | 0 |
+| decentraland/dapps-issues | Other | [[Events] Update the Share link to use the new `jump-in` site.](https://github.com/decentraland/dapps-issues/issues/247) | 0 |
+| decentraland/dapps-issues | Other | [Add a banner to communicate possible downtimes of our/thirdparty services](https://github.com/decentraland/dapps-issues/issues/20) | 0 |
 | decentraland/decentraland-connect | TypeScript | [Remove unussed network rpc urls](https://github.com/decentraland/decentraland-connect/issues/59) | 0 |
 | decentraland/decentraland-connect | TypeScript | [Unhandled PollingBlockTracker error crashes the explorer](https://github.com/decentraland/decentraland-connect/issues/41) | 0 |
 | decentraland/decentraland-connect | TypeScript | [Remove unused files from the public release](https://github.com/decentraland/decentraland-connect/issues/28) | 0 |
 | decentraland/decentraland-connect | TypeScript | [Consider tracking provider method usage](https://github.com/decentraland/decentraland-connect/issues/13) | 0 |
 | decentraland/decentraland-dapps | TypeScript | [Support Trezor for meta txs](https://github.com/decentraland/decentraland-dapps/issues/220) | 0 |
+| decentraland/decentraland-dapps | TypeScript | [Always show metamask button enable](https://github.com/decentraland/decentraland-dapps/issues/186) | 1 |
 | decentraland/decentraland-dapps | TypeScript | [Make the track function `add` generic so we can type the action it supplies](https://github.com/decentraland/decentraland-dapps/issues/143) | 0 |
 | decentraland/explorer | TypeScript | [Add new AvatarModifier: Force camera mode](https://github.com/decentraland/explorer/issues/1948) | 0 |
+| decentraland/explorer | TypeScript | [Switch to `?x=1&y=2` instead of `?position=1%C02`](https://github.com/decentraland/explorer/issues/1430) | 1 |
+| decentraland/explorer | TypeScript | [Blocking error on console: "Warning: Unsupported graphics API WebGL 2.0"](https://github.com/decentraland/explorer/issues/1333) | 1 |
 | decentraland/explorer-website | TypeScript | [Add prettier](https://github.com/decentraland/explorer-website/issues/107) | 0 |
+| decentraland/godot-explorer | Rust | [[Bug]: Interaction Feedback Doesn't Trigger when holding one Control (E.g Joystick)](https://github.com/decentraland/godot-explorer/issues/1170) | 0 |
 | decentraland/governance | TypeScript | [Formatting within comments is not displayed correctly](https://github.com/decentraland/governance/issues/776) | 0 |
 | decentraland/jump-site | TypeScript | [[Jump Site] - Fix the thumbnails for the scenes and events are not correctly scaled.](https://github.com/decentraland/jump-site/issues/53) | 0 |
 | decentraland/kernel | TypeScript | [Move empty parcels to their own repository](https://github.com/decentraland/kernel/issues/794) | 0 |
+| decentraland/land | Solidity | [docs needed](https://github.com/decentraland/land/issues/154) | 8 |
+| decentraland/marketplace | TypeScript | [It's hard to detect when the kebab menu of the ListCard is clickable](https://github.com/decentraland/marketplace/issues/1866) | 2 |
 | decentraland/marketplace | TypeScript | [Wait until all the profiles are loaded before showing the modal with list of users that picks the item](https://github.com/decentraland/marketplace/issues/1620) | 0 |
+| decentraland/marketplace | TypeScript | [Create a high order component that redirects to the Sign In Page if the user is not connected](https://github.com/decentraland/marketplace/issues/1522) | 4 |
+| decentraland/marketplace | TypeScript | [Capitalize land filter words](https://github.com/decentraland/marketplace/issues/1395) | 1 |
 | decentraland/marketplace | TypeScript | [Move the view listing button from the rental box to the top card in the land management page](https://github.com/decentraland/marketplace/issues/1393) | 0 |
 | decentraland/marketplace | TypeScript | [Add a message explaining how bids are going to be affected in the confirm rental listing modal](https://github.com/decentraland/marketplace/issues/1390) | 0 |
 | decentraland/marketplace | TypeScript | [Add a link to the documentation in the confirm listing modal](https://github.com/decentraland/marketplace/issues/1078) | 0 |
 | decentraland/marketplace | TypeScript | [Add a link to the operator's documentation in the confirm rent modal](https://github.com/decentraland/marketplace/issues/1045) | 0 |
 | decentraland/marketplace | TypeScript | [Add a tooltip to the proceed button if the price is not set in the confirm rent modal](https://github.com/decentraland/marketplace/issues/1037) | 0 |
 | decentraland/marketplace | TypeScript | [[Browse Page] Add Rarities + Collections filters](https://github.com/decentraland/marketplace/issues/737) | 0 |
+| decentraland/marketplace | TypeScript | [Inject `title` and description for each page](https://github.com/decentraland/marketplace/issues/603) | 1 |
 | decentraland/marketplace | TypeScript | [Check why 2 requests to fetch the store are sent at the same time](https://github.com/decentraland/marketplace/issues/575) | 0 |
+| decentraland/marketplace | TypeScript | [Show full name when hovering over Lands and Wearables](https://github.com/decentraland/marketplace/issues/590) | 2 |
 | decentraland/marketplace | TypeScript | [Move Mint Item functionality to the marketplace](https://github.com/decentraland/marketplace/issues/543) | 0 |
 | decentraland/profile | TypeScript | [User FTU to interact with avatar](https://github.com/decentraland/profile/issues/114) | 0 |
+| decentraland/sdk | Other | [Remove the mandatory `?v=` from the renderer fetch](https://github.com/decentraland/sdk/issues/201) | 1 |
 | decentraland/ui2 | TypeScript | [Change JumpIn component behavior](https://github.com/decentraland/ui2/issues/284) | 0 |
 | decentraland/ui2 | TypeScript | [UI issues in notifications](https://github.com/decentraland/ui2/issues/281) | 0 |
-| pytorch/probot | TypeScript | [deprecation of `number` for octokit](https://github.com/pytorch/probot/issues/62) | 1 |
-| decentraland/builder | TypeScript | [Add a search bar to NAMEs list](https://github.com/decentraland/builder/issues/3330) | 1 |
-| decentraland/builder | TypeScript | [Create auto-assign button on mint items from collection modal](https://github.com/decentraland/builder/issues/2442) | 1 |
-| decentraland/builder | TypeScript | [Add +- buttons to number input in mint items from collection](https://github.com/decentraland/builder/issues/2443) | 1 |
-| decentraland/builder | TypeScript | [Add link to documentation in the id field when creating TP collections](https://github.com/decentraland/builder/issues/1844) | 1 |
-| decentraland/builder | TypeScript | [Assigned Parcel Name dissapears after changing language](https://github.com/decentraland/builder/issues/1540) | 1 |
-| decentraland/creator-hub | TypeScript | [Need to click twice on "Create Scene" button to create the scene](https://github.com/decentraland/creator-hub/issues/832) | 1 |
-| decentraland/creator-hub | TypeScript | [Duplicated items appear at the bottom of the list](https://github.com/decentraland/creator-hub/issues/595) | 1 |
-| decentraland/decentraland-dapps | TypeScript | [Always show metamask button enable](https://github.com/decentraland/decentraland-dapps/issues/186) | 1 |
-| decentraland/explorer | TypeScript | [Switch to `?x=1&y=2` instead of `?position=1%C02`](https://github.com/decentraland/explorer/issues/1430) | 1 |
-| decentraland/explorer | TypeScript | [Blocking error on console: "Warning: Unsupported graphics API WebGL 2.0"](https://github.com/decentraland/explorer/issues/1333) | 1 |
-| decentraland/marketplace | TypeScript | [Capitalize land filter words](https://github.com/decentraland/marketplace/issues/1395) | 1 |
-| decentraland/marketplace | TypeScript | [Inject `title` and description for each page](https://github.com/decentraland/marketplace/issues/603) | 1 |
+| canonical/admission-webhook-operator | Python | [Add missing unit tests](https://github.com/canonical/admission-webhook-operator/issues/21) | 0 |
+| canonical/charmcraft | Python | [Determine whether requiring `libyaml-devel` on yum-based systems creates working charms](https://github.com/canonical/charmcraft/issues/1771) | 0 |
+| canonical/charmcraft | Python | [Improve the 'release' response when resources are automatically released with the charm](https://github.com/canonical/charmcraft/issues/847) | 2 |
+| canonical/charmcraft | Python | [The analyze command should also work on a not-packed charm](https://github.com/canonical/charmcraft/issues/642) | 3 |
+| canonical/charmed-kafka-snap | Shell | [Remove split controller implementation](https://github.com/canonical/charmed-kafka-snap/issues/51) | 1 |
+| canonical/charmed-kubeflow-uats | Jupyter Notebook | [Perform cleanup at the end of the KFP test](https://github.com/canonical/charmed-kubeflow-uats/issues/23) | 0 |
+| canonical/charmed-kubeflow-uats | Jupyter Notebook | [Format and lint `ipynb` files with `black`](https://github.com/canonical/charmed-kubeflow-uats/issues/8) | 1 |
+| canonical/charmed-mysql-rock | Other | [Add tests](https://github.com/canonical/charmed-mysql-rock/issues/47) | 1 |
+| canonical/charmed-mysql-snap | Shell | [Check MySQL shell version >= MySQL server version](https://github.com/canonical/charmed-mysql-snap/issues/77) | 1 |
+| canonical/charmed-postgresql-rock | Python | [Add integration test for verifying plugin shared objects consistency](https://github.com/canonical/charmed-postgresql-rock/issues/260) | 1 |
+| canonical/charmed-postgresql-snap | Python | [`start-pgbackrest-exporter.sh` does not support non-snapped environments](https://github.com/canonical/charmed-postgresql-snap/issues/169) | 2 |
+| canonical/charmed-temporal-solutions | HCL | [Switch PostgreSQL charm channel to 16/stable once released](https://github.com/canonical/charmed-temporal-solutions/issues/12) | 2 |
+| canonical/charmed-temporal-uats | Python | [Explore spread usage for UAT orchestration](https://github.com/canonical/charmed-temporal-uats/issues/14) | 1 |
+| canonical/charmed-temporal-uats | Python | [Add custom concierge config for desired environment for UATs](https://github.com/canonical/charmed-temporal-uats/issues/13) | 1 |
 | canonical/charming-actions | TypeScript | [Add `microk8s.inspect`?](https://github.com/canonical/charming-actions/issues/28) | 1 |
-| huggingface/huggingface.js | TypeScript | [Maximize button not working properly on Hosted inference API block](https://github.com/huggingface/huggingface.js/issues/335) | 2 |
-| ansible/ansible-ui | TypeScript | [Logo not loading correctly when building UI together with backend in a single image](https://github.com/ansible/ansible-ui/issues/3086) | 2 |
-| decentraland/marketplace | TypeScript | [It's hard to detect when the kebab menu of the ListCard is clickable](https://github.com/decentraland/marketplace/issues/1866) | 2 |
-| decentraland/marketplace | TypeScript | [Show full name when hovering over Lands and Wearables](https://github.com/decentraland/marketplace/issues/590) | 2 |
-| huggingface/chat-ui | TypeScript | [Add option for users to customize search engines in settings page](https://github.com/huggingface/chat-ui/issues/1756) | 3 |
-| huggingface/chat-ui | TypeScript | [Load past conversations using the most recent leaf to determine the visible conversation tree.](https://github.com/huggingface/chat-ui/issues/1208) | 3 |
-| huggingface/chat-ui | TypeScript | [System prompt not taken into account when web browsing.](https://github.com/huggingface/chat-ui/issues/1159) | 3 |
-| ansible/vscode-ansible | TypeScript | [Option to completely disable autocomplete](https://github.com/ansible/vscode-ansible/issues/837) | 3 |
-| pytorch/test-infra | TypeScript | [A better HUD menu for PyTorch repos family](https://github.com/pytorch/test-infra/issues/5226) | 4 |
-| huggingface/chat-ui | TypeScript | [Chrome app icon on macOS](https://github.com/huggingface/chat-ui/issues/1439) | 4 |
-| decentraland/marketplace | TypeScript | [Create a high order component that redirects to the Sign In Page if the user is not connected](https://github.com/decentraland/marketplace/issues/1522) | 4 |
-| pytorch/test-infra | TypeScript | [Mergebot merged a PR even though a review had been re-requested](https://github.com/pytorch/test-infra/issues/5543) | 5 |
-| huggingface/chat-ui | TypeScript | [Disabling Reasoning Summary as an Env Option](https://github.com/huggingface/chat-ui/issues/1720) | 5 |
-| huggingface/huggingface.js | TypeScript | [Tracking integration for Video Classification](https://github.com/huggingface/huggingface.js/issues/332) | 8 |
-| ansible/ansible-ui | TypeScript | [When job is running, selected EE is not visible in the UI, it appears only after it finishes](https://github.com/ansible/ansible-ui/issues/3085) | 8 |
-| godotengine/godot-docs | reStructuredText | [Object.get_meta & has_meta doc mentions is_valid_identifier but deprecated (prefer is_valid_ascii_identifier)](https://github.com/godotengine/godot-docs/issues/11870) | 0 |
-| godotengine/godot-docs | reStructuredText | [Add C# examples for custom BBCode](https://github.com/godotengine/godot-docs/issues/9334) | 0 |
-| godotengine/godot-docs | reStructuredText | [Parallax2D property descriptions do not specify units](https://github.com/godotengine/godot-docs/issues/9715) | 1 |
-| godotengine/godot-docs | reStructuredText | [make_canvas_position_local](https://github.com/godotengine/godot-docs/issues/8313) | 1 |
-| godotengine/godot-docs | reStructuredText | [Inconsistent code example between PhysicsShapeQueryParameters3D and PhysicsServer3D](https://github.com/godotengine/godot-docs/issues/8305) | 1 |
-| godotengine/godot-docs | reStructuredText | [Curve2D.get_closest_point() incorrectly documented](https://github.com/godotengine/godot-docs/issues/5894) | 1 |
-| godotengine/godot-docs | reStructuredText | [Viewport "use_hdr_2d" documentation point unclear](https://github.com/godotengine/godot-docs/issues/10044) | 2 |
-| godotengine/godot-docs | reStructuredText | [Physics2DDirectSpaceState does not specify local or global coordinates](https://github.com/godotengine/godot-docs/issues/3299) | 2 |
-| godotengine/godot-docs | reStructuredText | [PhysicsDirectSpaceState2D.get_rest_info claims not to use query motion but it does](https://github.com/godotengine/godot-docs/issues/10609) | 4 |
-| godotengine/godot-docs | reStructuredText | [Control class page doesn't mention ".release_focus()" in intro](https://github.com/godotengine/godot-docs/issues/9452) | 4 |
-| godotengine/godot-docs | reStructuredText | [WorkerThreadPool docs do not specify how Thread count is set](https://github.com/godotengine/godot-docs/issues/8937) | 4 |
+| canonical/chisel-docs | Other | [FAQ content needs redistribution](https://github.com/canonical/chisel-docs/issues/39) | 0 |
+| canonical/chisel-docs | Other | [Replace images in docs/explanation/mode-of-operation.md](https://github.com/canonical/chisel-docs/issues/31) | 2 |
+| canonical/chisel-releases | Other | [feat(iptables): improve `iptables` test coverage](https://github.com/canonical/chisel-releases/issues/997) | 0 |
+| canonical/chisel-releases | Other | [feat(systemd): improve `systemd` test coverage](https://github.com/canonical/chisel-releases/issues/989) | 1 |
+| canonical/chisel-releases | Other | [feat(25.10): arch-dependent gcc slices](https://github.com/canonical/chisel-releases/pull/896) | 2 |
+| canonical/chisel-releases | Other | [ci: bump `setup-lxd`](https://github.com/canonical/chisel-releases/issues/816) | 0 |
+| canonical/chisel-releases | Other | [feat(ci): pass `GITHUB_TOKEN` to the lxd spread machine](https://github.com/canonical/chisel-releases/issues/798) | 3 |
+| canonical/chisel-releases | Other | [ci: figure out which spread tests to run first](https://github.com/canonical/chisel-releases/issues/774) | 0 |
+| canonical/chisel-releases | Other | [ci: networking error preparing lxd in tests (2)](https://github.com/canonical/chisel-releases/issues/757) | 0 |
+| canonical/chisel-releases | Other | [ci: stale `test_install_slices`](https://github.com/canonical/chisel-releases/issues/718) | 1 |
+| canonical/chisel-releases | Other | [Add `drill` / `ldnsutils`](https://github.com/canonical/chisel-releases/issues/554) | 4 |
+| canonical/chisel-releases | Other | [Add `logrotate` slice](https://github.com/canonical/chisel-releases/issues/551) | 0 |
+| canonical/chisel-releases | Other | [Add `cron` slice](https://github.com/canonical/chisel-releases/issues/550) | 0 |
+| canonical/chisel-releases | Other | [Add `adduser` slice](https://github.com/canonical/chisel-releases/issues/549) | 1 |
+| canonical/chisel-releases | Other | [Add `socat` slice](https://github.com/canonical/chisel-releases/issues/533) | 0 |
+| canonical/chisel-releases | Other | [Where can we get `hostname`, `perl`, `opt` and `awk` slices?](https://github.com/canonical/chisel-releases/issues/502) | 3 |
+| canonical/chisel-releases | Other | [Please split common converters slice from libc6 gconv slice ](https://github.com/canonical/chisel-releases/issues/368) | 5 |
+| canonical/cloud-init | Python | [[enhancement]: fix typing of untyped-defs](https://github.com/canonical/cloud-init/issues/5445) | 7 |
+| canonical/cloud-init | Python | [[docs]: some DataSources missing from docs](https://github.com/canonical/cloud-init/issues/5341) | 2 |
+| canonical/cloud-init | Python | [[enhancement]: Relocate json schemas somewhere more sensible](https://github.com/canonical/cloud-init/issues/4688) | 6 |
+| canonical/cloud-init | Python | [[docs]: The terms "#include" and "#include-once" are difficult to define in the documentation](https://github.com/canonical/cloud-init/issues/4408) | 2 |
+| canonical/cloud-init | Python | [[docs]: The term "module" does not appear to be rigorously defined in the documentation](https://github.com/canonical/cloud-init/issues/4407) | 4 |
+| canonical/cloud-init | Python | [Don't Depend on GNU Date](https://github.com/canonical/cloud-init/issues/4357) | 3 |
+| canonical/cloud-init | Python | [[docs]: Default behaviour of ConfigDrive is unclear](https://github.com/canonical/cloud-init/issues/4310) | 3 |
+| canonical/cloud-init | Python | [ssh_import_id does not work on default user](https://github.com/canonical/cloud-init/issues/4306) | 7 |
+| canonical/cloud-init | Python | [Wrong return_code in analyze boot](https://github.com/canonical/cloud-init/issues/4245) | 3 |
+| canonical/cloud-init | Python | [World writable /usr/lib/cloud-init/clouddir should not be left behind](https://github.com/canonical/cloud-init/issues/4189) | 4 |
+| canonical/cloud-init | Python | [[feature] support key by url in apt configure module](https://github.com/canonical/cloud-init/issues/4076) | 16 |
+| canonical/cloud-init | Python | [cc_grub_dpkg: race condition on dpkg-set-selections lock](https://github.com/canonical/cloud-init/issues/4010) | 3 |
+| canonical/cloud-init | Python | [docs: update rtd documentation for altcloud](https://github.com/canonical/cloud-init/issues/3968) | 3 |
+| canonical/cloud-init | Python | [Misleading ssh_redirect_user warning](https://github.com/canonical/cloud-init/issues/3924) | 0 |
+| canonical/cloud-init | Python | [genisoimage may be going away](https://github.com/canonical/cloud-init/issues/3838) | 4 |
+| canonical/cloud-init | Python | [cloud-init network config 2 rename does not match with name](https://github.com/canonical/cloud-init/issues/3229) | 3 |
+| canonical/cloud-init | Python | [package-update-upgrade-install does not update when run with --frequency=always](https://github.com/canonical/cloud-init/issues/3218) | 7 |
+| canonical/cos-alerter | Python | [Covererage needs to be fixed](https://github.com/canonical/cos-alerter/issues/90) | 0 |
+| canonical/cos-coordinated-workers | Python | [Reword error status message for misconfigured worker](https://github.com/canonical/cos-coordinated-workers/issues/11) | 0 |
+| canonical/cos-lib | Python | [Feat: Improve Nginx performance](https://github.com/canonical/cos-lib/issues/145) | 0 |
+| canonical/cos-lib | Python | [allow using cosl.coordinated_workers.S3ConnectionInfo outside of tempo-loki-mimir](https://github.com/canonical/cos-lib/issues/119) | 7 |
+| canonical/cos-lib | Python | [better tests for unhappy paths](https://github.com/canonical/cos-lib/issues/100) | 4 |
+| canonical/cos-lib | Python | [add helper for discovering and aliasing system architecture](https://github.com/canonical/cos-lib/issues/29) | 0 |
+| canonical/cos-proxy-operator | Python | [Wrongly formatted alert rules are silently not loaded](https://github.com/canonical/cos-proxy-operator/issues/166) | 1 |
+| canonical/cos-proxy-operator | Python | [Fix typing](https://github.com/canonical/cos-proxy-operator/issues/165) | 0 |
+| canonical/craft-providers | Python | [fix type checking](https://github.com/canonical/craft-providers/issues/326) | 1 |
+| canonical/craft-providers | Python | [fix linter warnings](https://github.com/canonical/craft-providers/issues/325) | 0 |
+| canonical/data-platform-workflows | Python | [Improve checks on `_promote_charms` action](https://github.com/canonical/data-platform-workflows/issues/369) | 1 |
+| canonical/dex-auth-operator | Python | [Expected content of `connectors` config is not intuitive, add validation and documentation](https://github.com/canonical/dex-auth-operator/issues/42) | 1 |
+| canonical/etrace | Go | [error message should be smarter](https://github.com/canonical/etrace/issues/28) | 0 |
+| canonical/etrace | Go | [fail with nicer message when no window session is available](https://github.com/canonical/etrace/issues/27) | 0 |
+| canonical/etrace | Go | [doesn't complain when prepare/restore scripts are not executable](https://github.com/canonical/etrace/issues/4) | 0 |
+| canonical/gh-jira-sync-bot | Python | [GH issue with two labels causes two jira tickets created](https://github.com/canonical/gh-jira-sync-bot/issues/71) | 5 |
+| canonical/gh-jira-sync-bot | Python | [Issue is created on closure](https://github.com/canonical/gh-jira-sync-bot/issues/40) | 2 |
+| canonical/gh-jira-sync-bot | Python | [`status_mapping` seems broken](https://github.com/canonical/gh-jira-sync-bot/issues/39) | 1 |
+| canonical/iot-field-example-snaps | Shell | [Resolve lingering TODOs in automount-actions](https://github.com/canonical/iot-field-example-snaps/issues/2) | 0 |
+| canonical/iot-field-example-snaps | Shell | [Implement test suite for automount-actions](https://github.com/canonical/iot-field-example-snaps/issues/1) | 0 |
+| canonical/istio-operators | Python | [istio-pilot should look for signs of another istio install during deployment](https://github.com/canonical/istio-operators/issues/104) | 2 |
+| canonical/istio-operators | Python | [`ingress-auth` relation does not work for cross-model relations, needs `namespace` property in schema](https://github.com/canonical/istio-operators/issues/48) | 2 |
+| canonical/istio-operators | Python | [Add test for changed `kind` in `istio-gateway`](https://github.com/canonical/istio-operators/issues/37) | 0 |
+| canonical/jepsen.dqlite | Clojure | [Use go-dqlite's TLS connections](https://github.com/canonical/jepsen.dqlite/issues/103) | 0 |
+| canonical/juju-sdk-tutorial-k8s | Python | [Use charmcraft.yaml's 'charm-libs' feature](https://github.com/canonical/juju-sdk-tutorial-k8s/issues/64) | 0 |
+| canonical/juju-sdk-tutorial-k8s | Python | [Possible race condition in getting the database credentials](https://github.com/canonical/juju-sdk-tutorial-k8s/issues/41) | 0 |
+| canonical/karapace-operator | Python | [Karapace operator does not cleanup properly after TLS `relation-broken`](https://github.com/canonical/karapace-operator/issues/39) | 1 |
+| canonical/karma-alertmanager-proxy-k8s-operator | Python | [add option to clear the config and have the charm go back into BlockedState](https://github.com/canonical/karma-alertmanager-proxy-k8s-operator/issues/5) | 0 |
+| canonical/karma-alertmanager-proxy-k8s-operator | Python | [add config param for custom name for the proxied alertmanager cluster](https://github.com/canonical/karma-alertmanager-proxy-k8s-operator/issues/1) | 0 |
+| canonical/katib-operators | Python | [katib-* missing unit and integration tests](https://github.com/canonical/katib-operators/issues/5) | 2 |
+| canonical/kernel-docs | Other | [Fix docs link comment and permissions in GHA workflow](https://github.com/canonical/kernel-docs/issues/83) | 3 |
+| canonical/kernel-docs | Other | [Add recommended next steps for How to build a Linux kernel](https://github.com/canonical/kernel-docs/issues/10) | 4 |
+| canonical/kernel-docs | Other | [Glossary - LRM](https://github.com/canonical/kernel-docs/issues/9) | 6 |
+| canonical/kfp-operators | Python | [Change the default bucket name for Argo Workflows - currently always mlpipeline](https://github.com/canonical/kfp-operators/issues/132) | 4 |
+| canonical/kubeflow-ci | Python | [add `kubectl describe nodes` to logdump](https://github.com/canonical/kubeflow-ci/issues/94) | 0 |
+| canonical/kubeflow-ci | Python | [add `juju status` to log dump action](https://github.com/canonical/kubeflow-ci/issues/69) | 0 |
+| canonical/launchpad-manual | Other | [Missing page: list of tags for bug reports](https://github.com/canonical/launchpad-manual/issues/158) | 2 |
+| canonical/litmus-operators | Python | [use nginx module from charmlibs](https://github.com/canonical/litmus-operators/issues/122) | 1 |
+| canonical/lxd | Go | [Auth: Support CLI when OIDC client secret is configured](https://github.com/canonical/lxd/issues/17871) | 0 |
+| canonical/lxd | Go | [lxc image filters do not match displayed values](https://github.com/canonical/lxd/issues/17272) | 2 |
+| canonical/lxd | Go | [Can't select name column when filtering by IP](https://github.com/canonical/lxd/issues/17055) | 5 |
+| canonical/lxd | Go | [Add custom volume transfer to lxd-migrate](https://github.com/canonical/lxd/issues/11558) | 2 |
+| canonical/lxd | Go | [Add `wait_ready` nic config keys for IPv4/IPv6 routes](https://github.com/canonical/lxd/issues/11535) | 2 |
+| canonical/lxd | Go | [Add lxc config device add disk --type=block for containers ](https://github.com/canonical/lxd/issues/10077) | 20 |
+| canonical/microceph | Go | [MicroCeph: Replace :doc: with :ref: targets for internal cross-reference links](https://github.com/canonical/microceph/issues/605) | 3 |
+| canonical/microceph | Go | [Fault enabling replication](https://github.com/canonical/microceph/issues/559) | 4 |
+| canonical/microceph | Go | [Cannot enable SSO on Ceph Dashboard (missing python3-saml)](https://github.com/canonical/microceph/issues/397) | 2 |
+| canonical/microceph | Go | [`microceph disk list` shows un-supported disks as well](https://github.com/canonical/microceph/issues/243) | 1 |
+| canonical/microcloud | Go | [Terminate preseed joiners when initiator exits](https://github.com/canonical/microcloud/issues/597) | 0 |
+| canonical/microk8s-community-addons | Python | [Add support for Istio 1.16, 1.17 and1.18](https://github.com/canonical/microk8s-community-addons/issues/152) | 2 |
+| canonical/microk8s-community-addons | Python | [ArgoCD addon should include the argocd CLI](https://github.com/canonical/microk8s-community-addons/issues/148) | 0 |
+| canonical/microk8s-core-addons | Shell | [Extending DNS addon args ](https://github.com/canonical/microk8s-core-addons/issues/252) | 1 |
+| canonical/minio-operator | Python | [Broken charm icons for minio, mysql and katib-*](https://github.com/canonical/minio-operator/issues/45) | 0 |
+| canonical/minio-operator | Python | [Add `ingress` relation to expose console, api](https://github.com/canonical/minio-operator/issues/40) | 0 |
+| canonical/mir | C++ | [Support for natural (inversed) scrolling in the input configuration](https://github.com/canonical/mir/issues/4622) | 2 |
+| canonical/mir | C++ | [Pointer/touchpad acceleration bias configuration values not loaded at startup](https://github.com/canonical/mir/issues/4605) | 2 |
+| canonical/mir | C++ | [Replace `str(n)?cmp` with `std::string_view::operator==`](https://github.com/canonical/mir/issues/4567) | 5 |
+| canonical/mir | C++ | [`gmtime` and `localtime` are not thread safe and are outdated](https://github.com/canonical/mir/issues/4552) | 3 |
+| canonical/mir | C++ | [Move from `snprintf` and friends to `std::format*` and add checks for truncation](https://github.com/canonical/mir/issues/4549) | 0 |
+| canonical/mir | C++ | [The MirAL API should support more options for display configuration](https://github.com/canonical/mir/issues/4184) | 0 |
+| canonical/mir | C++ | [Add `wl_array` wrapper](https://github.com/canonical/mir/issues/4159) | 1 |
+| canonical/mir | C++ | [Review the symbol generator's hidden symbols list](https://github.com/canonical/mir/issues/4094) | 0 |
+| canonical/mir | C++ | [Send proper make and model information for `wl_output::geometry`](https://github.com/canonical/mir/issues/4061) | 4 |
+| canonical/mir | C++ | [`grimshot save output` captures all outputs, not just the active one](https://github.com/canonical/mir/issues/4014) | 0 |
+| canonical/mir | C++ | [Add support for `orientation: [vh]-mirrored`](https://github.com/canonical/mir/issues/3908) | 3 |
+| canonical/mir | C++ | [Unify mousekeys/mouse keys naming](https://github.com/canonical/mir/issues/3901) | 0 |
+| canonical/mir | C++ | [`MinimalWindowManager` should reposition windows to an active output when their output is removed](https://github.com/canonical/mir/issues/3895) | 2 |
+| canonical/mir | C++ | [Read current display mode as default](https://github.com/canonical/mir/issues/3179) | 0 |
+| canonical/mir | C++ | [Driver probe should check for presence of Wayland extension](https://github.com/canonical/mir/issues/2288) | 0 |
+| canonical/mir | C++ | [WindowManager::add_display()/remove_display()](https://github.com/canonical/mir/issues/2148) | 4 |
+| canonical/mir | C++ | [CompositorPerformance test uses its own idiosyncratic server runner](https://github.com/canonical/mir/issues/1653) | 0 |
+| canonical/mir | C++ | [manpages & help](https://github.com/canonical/mir/issues/1610) | 1 |
+| canonical/mir | C++ | [We're missing a way for Mir to report the socket it selects](https://github.com/canonical/mir/issues/1398) | 0 |
+| canonical/mlflow-operator | Python | [hardcoded aws default region](https://github.com/canonical/mlflow-operator/issues/21) | 0 |
+| canonical/multipass | C++ | [[snapshot] Lack of interactive stdin causes unhandled exception on `multipass restore`](https://github.com/canonical/multipass/issues/4825) | 0 |
+| canonical/multipass | C++ | [[snapshot] Raw error on snapshot deletion attempt on a running VM](https://github.com/canonical/multipass/issues/4824) | 1 |
+| canonical/multipass | C++ | [[sshfs] Multipass logs leaking filepaths from CI environments](https://github.com/canonical/multipass/issues/4195) | 1 |
+| canonical/multipass | C++ | [Issues with 3rd party compilation order](https://github.com/canonical/multipass/issues/3802) | 12 |
+| canonical/multipass | C++ | [Unify VM resource minima in Daemon/CLI/GUI](https://github.com/canonical/multipass/issues/3777) | 9 |
+| canonical/multipass | C++ | [Error "launch failed: Remote "release" is unknown or unreachable. If image mirror is enabled, please confirm it is valid." when launching image too quickly after installing Multipass](https://github.com/canonical/multipass/issues/3723) | 6 |
+| canonical/multipass | C++ | [New GUI doesn't respect theme](https://github.com/canonical/multipass/issues/3608) | 7 |
+| canonical/multipass | C++ | [[virtualbox@macOS] Purge-uninstall leaves VMs behind](https://github.com/canonical/multipass/issues/3571) | 3 |
+| canonical/multipass | C++ | [Bulk operations - Ability to perform actions on multiple nodes](https://github.com/canonical/multipass/issues/2404) | 11 |
+| canonical/multipass | C++ | [firewalld integration](https://github.com/canonical/multipass/issues/1236) | 2 |
+| canonical/multipass | C++ | [Allow specifying wildcards (`*`) for `--[ug]id-map` on mounts](https://github.com/canonical/multipass/issues/1200) | 10 |
+| canonical/multipass | C++ | [Ability to choose terminal emulator multipass.gui](https://github.com/canonical/multipass/issues/899) | 4 |
+| canonical/multipass | C++ | [Use host apt proxy configuration](https://github.com/canonical/multipass/issues/818) | 5 |
+| canonical/multipass | C++ | [Handle yaml-cpp exceptions from a cloud-init config better](https://github.com/canonical/multipass/issues/646) | 4 |
+| canonical/multipass | C++ | [Suggest opening up firewall when launching times out](https://github.com/canonical/multipass/issues/533) | 4 |
+| canonical/multipass | C++ | [Instrument function calls to debug-log arguments and return values](https://github.com/canonical/multipass/issues/428) | 5 |
+| canonical/mysql-operators | Python | [[k8s] Memory consumption calculation skewed up desproportionally for smaller (<3G) deployments](https://github.com/canonical/mysql-operators/issues/18) | 2 |
+| canonical/oidc-gatekeeper-operator | Python | [`client-secret` isn't used.](https://github.com/canonical/oidc-gatekeeper-operator/issues/27) | 4 |
+| canonical/open-documentation-academy | Python | [Rockcraft: Update text to American spelling](https://github.com/canonical/open-documentation-academy/issues/332) | 8 |
+| canonical/open-documentation-academy | Python | [Charmed Ceph: Stylistic inconsistencies in the how-to index](https://github.com/canonical/open-documentation-academy/issues/280) | 15 |
+| canonical/open-documentation-academy | Python | [MicroCeph: Replace :doc: with :ref: targets for internal cross-reference links (3)](https://github.com/canonical/open-documentation-academy/issues/279) | 8 |
+| canonical/open-documentation-academy | Python | [Charmed Ceph: Replace gerunds with imperatives](https://github.com/canonical/open-documentation-academy/issues/278) | 14 |
+| canonical/open-documentation-academy | Python | [MicroCeph: Replace :doc: with :ref: targets for internal cross-reference links (2)](https://github.com/canonical/open-documentation-academy/issues/277) | 10 |
+| canonical/open-documentation-academy | Python | [[Ubuntu Project] Add (describe) a glossary term: Continuous Integration (CI)](https://github.com/canonical/open-documentation-academy/issues/272) | 7 |
+| canonical/open-documentation-academy | Python | [[Ubuntu Project] Add (describe) a glossary term: branch](https://github.com/canonical/open-documentation-academy/issues/246) | 3 |
+| canonical/open-documentation-academy | Python | [Ubuntu Core: replace Markdown links with MyST references](https://github.com/canonical/open-documentation-academy/issues/243) | 21 |
+| canonical/open-documentation-academy | Python | [Launchpad: Add an info box on the discontinuation of support for Bazaar](https://github.com/canonical/open-documentation-academy/issues/240) | 4 |
+| canonical/open-documentation-academy | Python | [Website: Create an article summarizing the presentation "Documentation as code" done by Robert Kratky](https://github.com/canonical/open-documentation-academy/issues/229) | 9 |
+| canonical/open-documentation-academy | Python | [Ubuntu Server: building up the glossary](https://github.com/canonical/open-documentation-academy/issues/166) | 29 |
+| canonical/open-documentation-academy | Python | [Launchpad: fix broken links](https://github.com/canonical/open-documentation-academy/issues/78) | 7 |
+| canonical/open-documentation-academy | Python | [LXD: configure `cloud-init` from a file](https://github.com/canonical/open-documentation-academy/issues/63) | 6 |
+| canonical/packer-maas | HCL | [feat: add pve8.4 packer configs](https://github.com/canonical/packer-maas/pull/317) | 15 |
+| canonical/parca-scrape-target-operator | Python | [Add CONTRIBUTING.md](https://github.com/canonical/parca-scrape-target-operator/issues/55) | 0 |
+| canonical/pgbouncer-operator | Python | [Expose more configuration options](https://github.com/canonical/pgbouncer-operator/issues/579) | 1 |
+| canonical/pgbouncer-operator | Python | [Add configuration for max_prepared_statements](https://github.com/canonical/pgbouncer-operator/issues/425) | 3 |
+| canonical/pgbouncer-operator | Python | [Block the charm if there is no client relation](https://github.com/canonical/pgbouncer-operator/issues/252) | 1 |
+| canonical/postgresql-k8s-operator | Python | [PostgreSQL K8s charm failed to deploy after removing with `--force --no-wait` (due to K8s service availability)](https://github.com/canonical/postgresql-k8s-operator/issues/1171) | 2 |
+| canonical/postgresql-k8s-operator | Python | [Add test for DCS failsafe mode, simulating k8s API being down](https://github.com/canonical/postgresql-k8s-operator/issues/792) | 1 |
+| canonical/postgresql-k8s-operator | Python | [Test: scale application to zero units ](https://github.com/canonical/postgresql-k8s-operator/issues/508) | 1 |
+| canonical/postgresql-k8s-operator | Python | [Test charm recovery after instance restart.](https://github.com/canonical/postgresql-k8s-operator/issues/470) | 1 |
+| canonical/postgresql-k8s-operator | Python | [Improve config options validation](https://github.com/canonical/postgresql-k8s-operator/issues/295) | 1 |
+| canonical/postgresql-operator | Python | [Move `--log-level-stderr=warn` to pgBackRest's configuration file](https://github.com/canonical/postgresql-operator/issues/1353) | 1 |
+| canonical/postgresql-operator | Python | [Running list-backups actions shortly after relation with s3-integrator results in IndexError](https://github.com/canonical/postgresql-operator/issues/699) | 2 |
+| canonical/postgresql-operator | Python | [Improve config options validation](https://github.com/canonical/postgresql-operator/issues/258) | 5 |
+| canonical/postgresql-test-app | Python | [Create a nightly test run for self-checking](https://github.com/canonical/postgresql-test-app/issues/148) | 1 |
+| canonical/powershell-snaps | Python | [Create CI validation for release channel names](https://github.com/canonical/powershell-snaps/issues/20) | 0 |
+| canonical/prometheus-k8s-operator | Python | [Metrics are still received after Grafana Agent stops](https://github.com/canonical/prometheus-k8s-operator/issues/643) | 0 |
+| canonical/pycloudlib | Python | [build status badge is obsolete in README.md](https://github.com/canonical/pycloudlib/issues/445) | 2 |
+| canonical/pycloudlib | Python | [Contributing guidelines seem outdated](https://github.com/canonical/pycloudlib/issues/377) | 1 |
+| canonical/pycloudlib | Python | [Consistent console_log() API](https://github.com/canonical/pycloudlib/issues/363) | 0 |
+| canonical/pyroscope-operators | Python | [use nginx module from charmlibs](https://github.com/canonical/pyroscope-operators/issues/285) | 1 |
+| canonical/redis-k8s-operator | Python | [Add integration test coverage for HA of metrics exporter](https://github.com/canonical/redis-k8s-operator/issues/86) | 3 |
+| canonical/redis-k8s-operator | Python | [Add integration tests that scale relating app](https://github.com/canonical/redis-k8s-operator/issues/48) | 0 |
+| canonical/rockcraft | Python | [docs: Running Flask, Django and FastAPI should be in a code block](https://github.com/canonical/rockcraft/issues/1145) | 1 |
+| canonical/rockcraft | Python | [Improve detection/setting of the PATH environment variable](https://github.com/canonical/rockcraft/issues/729) | 4 |
+| canonical/rockcraft | Python | [Help includes expand-extensions entry with reference to snapcraft.yaml](https://github.com/canonical/rockcraft/issues/658) | 1 |
+| canonical/script-exporter-operator | Python | [Change the path of script-exporter-script](https://github.com/canonical/script-exporter-operator/issues/12) | 0 |
+| canonical/seldon-core-operator | Jinja | [Add test that uses istio ingress](https://github.com/canonical/seldon-core-operator/issues/19) | 0 |
+| canonical/snap-vault | Shell | [Build date and commit ID missing from binary](https://github.com/canonical/snap-vault/issues/87) | 2 |
+| canonical/snapcraft | Python | [Recommend using newer versions of snapcraft](https://github.com/canonical/snapcraft/issues/4958) | 3 |
+| canonical/snapcraft | Python | [Add "--base=core2x"" option to "snapcraft extensions"](https://github.com/canonical/snapcraft/issues/4360) | 2 |
+| canonical/snapcraft-101-labs | Shell | [Repository cleanup](https://github.com/canonical/snapcraft-101-labs/issues/14) | 1 |
+| canonical/source-wand | Rust | [[Feature] Add repositories to Go dependencies](https://github.com/canonical/source-wand/issues/12) | 1 |
+| canonical/spark-integration-hub-k8s-operator | Python | [Charm errors when related to the s3-integrator and bucket name is empty](https://github.com/canonical/spark-integration-hub-k8s-operator/issues/150) | 5 |
+| canonical/spark-k8s-bundle | Python | [Make `secret-key`, `storage-account` and `container-name` fields required in TF variables for azure-storage](https://github.com/canonical/spark-k8s-bundle/issues/139) | 1 |
+| canonical/spark-k8s-toolkit-py | Python | [Prettify the output printed by the CLI commands](https://github.com/canonical/spark-k8s-toolkit-py/issues/56) | 1 |
+| canonical/specs.canonical.com | Python | [reviewers parser should ignore wrong cases](https://github.com/canonical/specs.canonical.com/issues/12) | 2 |
+| canonical/sphinx-stack | Other | [Replace value of ogp_image in conf.py to an image included in the repository instead of assets manager](https://github.com/canonical/sphinx-stack/issues/512) | 0 |
+| canonical/sphinx-stack | Other | [Underscores in anchor](https://github.com/canonical/sphinx-stack/issues/390) | 1 |
+| canonical/sphinx-stack | Other | [Make 'Sphinx python dependency build checks' optional](https://github.com/canonical/sphinx-stack/issues/332) | 1 |
+| canonical/sphinx-stack | Other | [Housekeeping: update preview logo](https://github.com/canonical/sphinx-stack/issues/215) | 0 |
+| canonical/sphinx-stack-docs | Other | ["Style guide" documents are superfluous and should be syntax guides](https://github.com/canonical/sphinx-stack-docs/issues/7) | 0 |
+| canonical/tempo-operators | Python | [Wrong `LogQL` in dashboard](https://github.com/canonical/tempo-operators/issues/272) | 1 |
+| canonical/tempo-operators | Python | [Annoying tracing lib warning: charm tracing buffer exceeds max history length (100 events)](https://github.com/canonical/tempo-operators/issues/257) | 2 |
+| canonical/tempo-operators | Python | [Handle multiple ingresses cleanly](https://github.com/canonical/tempo-operators/issues/245) | 2 |
+| canonical/testflinger | Python | [Add website URL field for agents](https://github.com/canonical/testflinger/issues/794) | 3 |
+| canonical/test_observer | Python | [UI is unusable to bulk approve large number of environments.](https://github.com/canonical/test_observer/issues/736) | 3 |
+| canonical/traefik-k8s-operator | Python | [Output the correct message when traefik is not deployed with --trust](https://github.com/canonical/traefik-k8s-operator/issues/589) | 1 |
+| canonical/traefik-k8s-operator | Python | [Refactor or remove `redirect_https` from the ingress/ingress-per-app interface](https://github.com/canonical/traefik-k8s-operator/issues/502) | 2 |
+| canonical/traefik-k8s-operator | Python | [missing substitution in log message](https://github.com/canonical/traefik-k8s-operator/issues/439) | 1 |
+| canonical/ubuntu-security-documentation | Python | [[security-features] `cloud-prng-seed.rst` contains dead links](https://github.com/canonical/ubuntu-security-documentation/issues/80) | 1 |
+| canonical/ubuntu-security-documentation | Python | [[compliance] Add links for mentioned standards](https://github.com/canonical/ubuntu-security-documentation/issues/77) | 1 |
+| canonical/ulwazi | CSS | [Cookie consent banner fails to show](https://github.com/canonical/ulwazi/issues/91) | 0 |
+| canonical/ulwazi | CSS | [Font size of numbers in numerated lists seems too big](https://github.com/canonical/ulwazi/issues/81) | 1 |
+| canonical/ulwazi | CSS | [Weirdly looking code blocks captions](https://github.com/canonical/ulwazi/issues/78) | 0 |
+| canonical/wlcs | C++ | [`xdg_toplevel_stable.cpp` cleanups](https://github.com/canonical/wlcs/issues/406) | 0 |
+| django/birthday20 | HTML | [Add social media links on event pages](https://github.com/django/birthday20/issues/101) | 3 |
+| django/birthday20 | HTML | [Vendor third-party assets (leaflet)](https://github.com/django/birthday20/issues/70) | 10 |
+| django/djangoproject.com | Python | [Redirect from /about to /foundation](https://github.com/django/djangoproject.com/issues/2428) | 7 |
+| django/djangoproject.com | Python | [Add link to 'Stable' doc version in the Warning Alert on top](https://github.com/django/djangoproject.com/issues/2094) | 11 |
+| django/djangoproject.com | Python | [Add link to new minutes repo](https://github.com/django/djangoproject.com/issues/2079) | 7 |
+| django/djangoproject.com | Python | [New content: Accessibility statement](https://github.com/django/djangoproject.com/issues/1430) | 13 |
+| django/djangoproject.com | Python | [Make right sidebar independent from main content](https://github.com/django/djangoproject.com/issues/1366) | 12 |
+| django/djangoproject.com | Python | [Improve 404 page](https://github.com/django/djangoproject.com/issues/1347) | 14 |
+| django/djangoproject.com | Python | [Improvements to the Corporate Sponsor Experience](https://github.com/django/djangoproject.com/issues/1171) | 8 |
+| django/djangoproject.com | Python | [Improve Documentation by having list of topics fixed on the left and table of contents on the right ](https://github.com/django/djangoproject.com/issues/1129) | 7 |
+| django/djangoproject.com | Python | [Docs for old supported versions should indicate that a newer version is available](https://github.com/django/djangoproject.com/issues/1122) | 7 |
+| django/djangoproject.com | Python | [Support switching languages on non-docs sites](https://github.com/django/djangoproject.com/issues/883) | 6 |
+| django/djangoproject.com | Python | [Remove non-canonical docs versions from sitemap.xml](https://github.com/django/djangoproject.com/issues/878) | 9 |
+| django/djangoproject.com | Python | [Use noindex meta tag or header, not robots.txt, to block untranslated docs pages](https://github.com/django/djangoproject.com/issues/877) | 8 |
+| django/djangoproject.com | Python | [fundraising: 'customer.subscription.deleted' webhook event always gets 404 response](https://github.com/django/djangoproject.com/issues/764) | 5 |
+| django/djangoproject.com | Python | [Documentation table of contents is hard to reach on mobile devices](https://github.com/django/djangoproject.com/issues/494) | 4 |
+| django/djangoproject.com | Python | [Localize the fundraising app](https://github.com/django/djangoproject.com/issues/377) | 17 |
+| zeromicro/goctl-swagger | PHP | [support for openapi 3.0 ](https://github.com/zeromicro/goctl-swagger/issues/52) | 0 |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you are wondering where to begin in the  journey contributing to open-source 
 
 
 
-## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-11</sub></sub>
+## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-12</sub></sub>
 
 | Repo | Language | Title | Comments |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you are wondering where to begin in the  journey contributing to open-source 
 
 
 
-## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-10</sub></sub>
+## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-11</sub></sub>
 
 | Repo | Language | Title | Comments |
 | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you are wondering where to begin in the  journey contributing to open-source 
 
 
 
-## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-09</sub></sub>
+## List of Good First Issues to start Collaborating! :surfer: <sub><sub>Last run: 2026-05-10</sub></sub>
 
 | Repo | Language | Title | Comments |
 | --- | --- | --- | --- |

--- a/app/core/api_handler.py
+++ b/app/core/api_handler.py
@@ -30,22 +30,24 @@ class RepoManager:
     @staticmethod
     def extract_repos(user, session, repos_per_page=100):
         """
-        Takes a username, aiohttp sesion and number of repos pr page
-        and returns list of lists of repositories. 
+        Takes a username, session and number of repos per page
+        and returns a dictionary mapping repo URLs to their primary language.
         """
-        repos = []
+        repos_with_language = {}
         number_of_repos = RepoManager().extract_number_of_repos(user, session)
         number_of_pages = Utils().divide_and_round_up(number_of_repos)
-        for page in range(1,number_of_pages+1):
+        for page in range(1, number_of_pages + 1):
             user_url = f"https://api.github.com/users/{user}/repos?page={page}&per_page={repos_per_page}"
             resp_json = APIClient().make_request(user_url, session)
-            try: 
-                repos += [x['url'] for x in resp_json]
+            try:
+                for repo in resp_json:
+                    lang = repo.get('language')
+                    repos_with_language[repo['url']] = lang if lang else "Other"
             except TypeError as error:
                 logging.error(error)
                 raise
 
-        return repos
+        return repos_with_language
 
 
 class IssueManager:
@@ -70,41 +72,26 @@ class IssueManager:
             logging.error(error)
             raise
 
-    @staticmethod
-    def extract_language(repo, session):
-        """
-        Takes the repo API endpoint and aiohttp session
-        and returns the principal language of the repository.
-        """
-        resp_json = APIClient().make_request(repo, session)
-        try:
-            language = resp_json['language']
-            if language == None:
-                language = "Other"
-        except KeyError as error:
-            logging.error(error)
-            raise
-            
-        return language
 
     @staticmethod
-    def extract_issues(repo, session, labels="good first issue"):
+    def extract_issues_by_user(user, session, labels="good first issue"):
         """
-        Takes the repo API endpoing and aiohttp session
-        and returns issues  with defined labels and state.
+        Uses GitHub Search API to find all issues with defined labels
+        for a specific user/organization.
         """
         issues = []
-        language = IssueManager().extract_language(repo, session)
-        issues_url = repo + f"/issues?labels={labels}"
+        search_url = f"https://api.github.com/search/issues?q=user:{user}+label:\"{labels}\"+state:open+is:issue&per_page=100"
         
-        resp_json = APIClient().make_request(issues_url, session)
+        resp_json = APIClient().make_request(search_url, session)
         try:
-            cleaned_issues = [(language, issue) for issue in resp_json]
-            issues += cleaned_issues
-        except TypeError as error:
-            logging.error(error)
-            raise
-
+            # Search API returns total_count and items
+            items = resp_json.get('items', [])
+            # We don't have the language here, so we return raw issues
+            # We will map the language in update_issues.py
+            issues = items
+        except Exception as error:
+            logging.info(f"Error fetching issues for {user}: {error}")
+            
         return issues
 
 

--- a/app/update_issues.py
+++ b/app/update_issues.py
@@ -46,18 +46,28 @@ def main(args):
     """
     with requests.Session() as session:
         session.headers.update(HEADERS)
-        logging.info("Gathering repositories...")
-        repos = [RepoManager().extract_repos(user,  session) for user in USERNAMES]
-        repos = Utils().create_list_from_lists(repos)
-        logging.info(f"Extracted {len(repos)} public repositories.")
+        
+        logging.info("Gathering repositories and language data...")
+        repo_lang_map = {}
+        for user in USERNAMES:
+            user_repos = RepoManager().extract_repos(user, session)
+            repo_lang_map.update(user_repos)
+        logging.info(f"Extracted language data for {len(repo_lang_map)} repositories.")
 
-        logging.info(f"Gathering issues...")
-        raw_issues = [IssueManager().extract_issues(repo, session) for repo in repos]
-        raw_issues = Utils().create_list_from_lists(raw_issues)
-        logging.info(f"Extracted {len(raw_issues)} issues.")
+        logging.info(f"Gathering issues using Search API...")
+        all_raw_issues = []
+        for user in USERNAMES:
+            user_issues = IssueManager().extract_issues_by_user(user, session)
+            # Map each issue to its repo's language
+            for issue in user_issues:
+                repo_url = issue['repository_url']
+                lang = repo_lang_map.get(repo_url, "Other")
+                all_raw_issues.append((lang, issue))
+        
+        logging.info(f"Extracted {len(all_raw_issues)} issues.")
 
         logging.info("Normalizing data...")
-        issues = [IssueManager().extract_issue_data(issue) for issue in raw_issues]
+        issues = [IssueManager().extract_issue_data(issue) for issue in all_raw_issues]
         logging.info(f"Normalized data.")
         logging.info(f"First issues row: {issues[0]}")
 
@@ -68,7 +78,7 @@ def main(args):
             logging.info(f"Wrote {len(issues)} issues to {args.output}")
 
         logging.info(f"Rendered README file.")
-        logging.info(f"Total repositories gathered: {len(repos)}")        
+        logging.info(f"Total repositories gathered: {len(repo_lang_map)}")        
         logging.info(f"Total Issues gathered: {len(issues)}")
 
         


### PR DESCRIPTION
Closes #75 

## Problem
The code makes excessive GitHub API calls:
1. `extract_language()` makes a **separate API call per repo** to fetch language, even though the `/repos` endpoint already includes the `language` field in its response.
2. `extract_issues()` loops over **every repository individually** to find issues with the "good first issue" label, resulting in N API calls for N repos.

## Solution

### 1. Language caching (addresses thought #1 from the issue)
Modified `extract_repos()` to return a `{repo_url: language}` dictionary instead of a plain URL list. Since the `/users/{user}/repos` response already contains the `language` field, we now capture it during repo fetching — eliminating the need for `extract_language()` entirely.

### 2. GitHub Search API (addresses thought #2 from the issue)
Replaced per-repo issue fetching with a single GitHub Search API call per user/org:
