### PR TITLE
Fixed pipe character breaking markdown table rendering in README

### DIFF
--- a/app/core/api_handler.py
+++ b/app/core/api_handler.py
@@ -127,7 +127,7 @@ class TemplateManager:
                 results.append({
                     'repo': row['repo'],
                     'language': row['language'],
-                    'title': row['title'],
+                    'title': row['title'].replace('|', '\\|'), # Escape '|' to avoid breaking markdown table rows
                     'url': row['url'],
                     'comments': row['comments'],
                 })


### PR DESCRIPTION
Fixes #91

I ran the project locally using pytorch as the username and reproduced the issue. Some issue titles contain pipe characters (|), for example: [MX | Triton] Create MX matmul op using new scaled_dot op in Triton.Since | is interpreted as a column separator in markdown tables, it caused rows in the generated README table to render incorrectly.This PR fixes the issue by escaping pipe characters in issue titles inside render_template() in app/core/api_handler.py before rendering the markdown table.