### PR TITLE
fix: use column names instead of hardcoded indexes for filtering and sorting

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -76,6 +76,11 @@
     const sortComments = $("sortComments");
     const table = $("issuesTable");
 
+    // Resolve column name to index from the header row
+    function getColumnIndex(header, name) {
+        return header.findIndex(col => col.trim().toLowerCase() === name.toLowerCase());
+    }
+
     function renderTable(data) {
 
         table.innerHTML = "";
@@ -108,31 +113,35 @@
     function updateTable() {
 
         const header = issuesData[0];
-        let rows = issuesData.slice(1);
+        const langIdx = getColumnIndex(header, "language");
+        const commentsIdx = getColumnIndex(header, "comments");
+        const rows = issuesData.slice(1);
+
+        let filtered = rows;
 
         if (currentSearch !== "") {
-            rows = rows.filter(row => {
+            filtered = filtered.filter(row => {
                 return row.join(" ").toLowerCase().includes(currentSearch.toLowerCase())
             });
         }
         
-        if (currentLanguage !== "") {
-            rows = rows.filter(row => {
-                return row[1] === currentLanguage
+        if (currentLanguage !== "" && langIdx !== -1) {
+            filtered = filtered.filter(row => {
+                return row[langIdx] === currentLanguage
             });
         }
 
-        if (sortMode === 1) {
-            rows.sort(
-                (a,b) => Number(b[4]) - Number(a[4])
+        if (sortMode === 1 && commentsIdx !== -1) {
+            filtered.sort(
+                (a,b) => Number(b[commentsIdx]) - Number(a[commentsIdx])
             );
-        } else if (sortMode === 2) {
-            rows.sort(
-                (a,b) => Number(a[4]) - Number(b[4])
+        } else if (sortMode === 2 && commentsIdx !== -1) {
+            filtered.sort(
+                (a,b) => Number(a[commentsIdx]) - Number(b[commentsIdx])
             );
         }
 
-        renderTable([header, ...rows]);
+        renderTable([header, ...filtered]);
     }
 
     searchBox.addEventListener("input", () => {
@@ -174,10 +183,12 @@
                 skipEmptyLines: true,
                 complete: function(results) {
                     issuesData = results.data;
+                    const header = issuesData[0];
+                    const langIdx = getColumnIndex(header, "language");
 
                     const languages = [
                         ...new Set(
-                            issuesData.slice(1).map(row => row[1])
+                            issuesData.slice(1).map(row => langIdx !== -1 ? row[langIdx] : "")
                         )
                     ];
 


### PR DESCRIPTION
## What

Replaced hardcoded CSV column indexes (`row[1]` for language, `row[4]` for comments) with a helper function `getColumnIndex()` that resolves column indices from the CSV header row at runtime.

## Why

If the CSV column order changes (e.g., a new column is added before language or comments), filtering by language, sorting by comments, and the language filter dropdown would silently break. Using the header row as the source of truth makes the code resilient to column reordering.

## Testing

- Verified the language filter still populates correctly from the `language` column
- Verified filtering by language still works
- Verified sort-by-comments (ascending/descending/default) still works
- All existing behavior preserved for the current CSV layout