### PR TITLE
fix: use CSV header to resolve column indices dynamically

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -64,6 +64,7 @@
     let currentSearch = "";
     let currentLanguage = "";
     let sortMode = 0;
+    let colIdx = {};
     /* 
         0 = DEFAULT
         1 = DESCENDING
@@ -118,17 +119,17 @@
         
         if (currentLanguage !== "") {
             rows = rows.filter(row => {
-                return row[1] === currentLanguage
+                return row[colIdx.language] === currentLanguage
             });
         }
 
         if (sortMode === 1) {
             rows.sort(
-                (a,b) => Number(b[4]) - Number(a[4])
+                (a,b) => Number(b[colIdx.comments]) - Number(a[colIdx.comments])
             );
         } else if (sortMode === 2) {
             rows.sort(
-                (a,b) => Number(a[4]) - Number(b[4])
+                (a,b) => Number(a[colIdx.comments]) - Number(b[colIdx.comments])
             );
         }
 
@@ -174,10 +175,15 @@
                 skipEmptyLines: true,
                 complete: function(results) {
                     issuesData = results.data;
+                    const header = issuesData[0];
+                    colIdx = {
+                        language: header.indexOf("language"),
+                        comments: header.indexOf("comments")
+                    };
 
                     const languages = [
                         ...new Set(
-                            issuesData.slice(1).map(row => row[1])
+                            issuesData.slice(1).map(row => row[colIdx.language])
                         )
                     ];
 


### PR DESCRIPTION
## Summary

The JavaScript code references CSV columns by fixed index (row[1] for language, row[4] for comments). If the CSV column order ever changes, filtering and sorting will silently break.

## Fix

Replace hardcoded indexes with dynamic lookup from the CSV header row:

- Added `colIdx` object that maps column names to their index positions
- Language filter now uses `row[colIdx.language]` instead of `row[1]`
- Sort by comments now uses `row[colIdx.comments]` instead of `row[4]`
- Language aggregation in the filter population also uses `colIdx.language`

The CSV header is: `repo,language,title,url,comments,labels,state`
- language = index 1
- comments = index 4

The fix is backwards-compatible with the current column order.

## Testing

- Single-file change (app/frontend/index.html)
- No functional changes to existing behavior — only resilience against future column reordering
- All references to row[N] that depended on column positions are updated

Fixes #108