### PR TITLE
fix: add mock_env_vars fixture and update test_extract_issue_data ass…

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -4,3 +4,8 @@ import requests
 @pytest.fixture
 def mock_session(mocker):
     return mocker.Mock(spec=requests.Session)
+
+@pytest.fixture
+def mock_env_vars(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "fake_token")
+    monkeypatch.setenv("ORGANIZATIONS", "fake_org")

--- a/app/tests/test_api_handler.py
+++ b/app/tests/test_api_handler.py
@@ -89,19 +89,21 @@ class TestIssueManager:
                 "repository_url": "https://api.github.com/repos/owner/repo",
                 "title": "Test Issue",
                 "html_url": "https://github.com/owner/repo/issues/1",
-                "comments": 5
+                "comments": 5,
+                "labels": [{"name": "good first issue"}],
+                "state": "open"
             }
         )
-        
+
         result = IssueManager().extract_issue_data(raw_issue)
-        
-        assert result == {
-            "repo": "owner/repo",
-            "language": "Python",
-            "title": "Test Issue",
-            "url": "https://github.com/owner/repo/issues/1",
-            "comments": 5
-        }
+
+        assert result["repo"] == "owner/repo"
+        assert result["language"] == "Python"
+        assert result["title"] == "Test Issue"
+        assert result["url"] == "https://github.com/owner/repo/issues/1"
+        assert result["comments"] == 5
+        assert "labels" in result
+        assert "state" in result
 
     @patch('app.core.api_handler.APIClient')
     def test_extract_language(self, mock_api_client):


### PR DESCRIPTION


## What does this PR do?
Added missing mock_env_vars fixture to `conftest.py` to fix 4 failing tests. Updated test_extract_issue_data to assert labels and state fields as required by the issue.

## Related Issue
Fixes #89

## Checklist
- [ x ] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ x ] I ran the project locally and tested my changes
- [ x ] I verified my changes are working as expected
- [ ] This PR description is written by me, not by AI
