### PR TITLE
Repair stale tests for current issue fetching behavior

### DIFF
--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,6 +1,13 @@
 import pytest
 import requests
 
+
 @pytest.fixture
 def mock_session(mocker):
     return mocker.Mock(spec=requests.Session)
+
+
+@pytest.fixture
+def mock_env_vars(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setenv("USERNAMES", "owner")

--- a/app/tests/test_api_handler.py
+++ b/app/tests/test_api_handler.py
@@ -43,11 +43,11 @@ class TestRepoManager:
         result = RepoManager().extract_repos('test_user', mock_api_instance)
 
         assert len(result) == 3
-        assert result == [
-            "https://api.github.com/repos/owner/repo1",
-            "https://api.github.com/repos/owner/repo2",
-            "https://api.github.com/repos/owner/repo3"
-        ]
+        assert result == {
+            "https://api.github.com/repos/owner/repo1": "Other",
+            "https://api.github.com/repos/owner/repo2": "Other",
+            "https://api.github.com/repos/owner/repo3": "Other",
+        }
         
         # Verify API calls
         assert mock_api_instance.make_request.call_count == 2
@@ -100,81 +100,44 @@ class TestIssueManager:
             "language": "Python",
             "title": "Test Issue",
             "url": "https://github.com/owner/repo/issues/1",
-            "comments": 5
+            "comments": 5,
+            "labels": [],
+            "state": "open",
         }
 
     @patch('app.core.api_handler.APIClient')
-    def test_extract_language(self, mock_api_client):
+    def test_extract_issues_by_user(self, mock_api_client):
         mock_api_instance = MagicMock()
         mock_api_client.return_value = mock_api_instance
-        mock_api_instance.make_request.return_value = {"language": "Python"}
-
-        result = IssueManager().extract_language("https://api.github.com/repos/owner/repo", mock_api_instance)
-
-        assert result == "Python"
-        mock_api_instance.make_request.assert_called_once_with("https://api.github.com/repos/owner/repo", mock_api_instance)
-
-    @patch('app.core.api_handler.APIClient')
-    def test_extract_issues(self, mock_api_client):
-        mock_api_instance = MagicMock()
-        mock_api_client.return_value = mock_api_instance
-        
-        # Mock the language request
-        mock_api_instance.make_request.side_effect = [
-            {"language": "Python"},  # First call for extract_language
-            [  # Second call for issues
+        mock_api_instance.make_request.return_value = {
+            "items": [
                 {
+                    "repository_url": "https://api.github.com/repos/owner/repo",
                     "title": "Test Issue",
                     "html_url": "https://github.com/owner/repo/issues/1",
-                    "comments": 5
+                    "comments": 5,
                 }
             ]
-        ]
+        }
 
-        result = IssueManager().extract_issues("https://api.github.com/repos/owner/repo", mock_api_instance)
+        result = IssueManager().extract_issues_by_user("test_user", mock_api_instance)
 
         assert len(result) == 1
-        assert result[0][0] == "Python"  # Language
-        assert result[0][1]["title"] == "Test Issue"
-        
-        # Verify API calls
-        assert mock_api_instance.make_request.call_count == 2
-        mock_api_instance.make_request.assert_any_call("https://api.github.com/repos/owner/repo", mock_api_instance)
-        mock_api_instance.make_request.assert_any_call("https://api.github.com/repos/owner/repo/issues?labels=good first issue", mock_api_instance)
-
-    @patch('app.core.api_handler.APIClient')
-    def test_extract_issue_data_error(self, mock_api_client):
-        raw_issue = (
-            "Python",
-            {
-                # Missing required keys
-                "repository_url": "https://api.github.com/repos/owner/repo"
-            }
+        assert result[0]["title"] == "Test Issue"
+        mock_api_instance.make_request.assert_called_once_with(
+            'https://api.github.com/search/issues?q=user:test_user+label:"good first issue"+state:open+is:issue&per_page=100',
+            mock_api_instance,
         )
-        
-        with pytest.raises(Exception):
-            IssueManager().extract_issue_data(raw_issue)
 
     @patch('app.core.api_handler.APIClient')
-    def test_extract_language_error(self, mock_api_client):
+    def test_extract_issues_by_user_empty_response(self, mock_api_client):
         mock_api_instance = MagicMock()
         mock_api_client.return_value = mock_api_instance
-        mock_api_instance.make_request.return_value = {}  # Missing 'language' key
+        mock_api_instance.make_request.return_value = {}
 
-        with pytest.raises(KeyError):
-            IssueManager().extract_language("https://api.github.com/repos/owner/repo", mock_api_instance)
+        result = IssueManager().extract_issues_by_user("test_user", mock_api_instance)
 
-    @patch('app.core.api_handler.APIClient')
-    def test_extract_issues_error(self, mock_api_client):
-        mock_api_instance = MagicMock()
-        mock_api_client.return_value = mock_api_instance
-        mock_api_instance.make_request.side_effect = [
-            {"language": "Python"},  # First call for extract_language
-            None  # Second call will cause TypeError
-        ]
-
-        with pytest.raises(TypeError):
-            IssueManager().extract_issues("https://api.github.com/repos/owner/repo", mock_api_instance)
+        assert result == []
 
 class TestUtils:
 
@@ -257,81 +220,34 @@ class TestTemplateManager:
 
         result = TemplateManager().format_response(issues)
 
-        assert len(result) == 2  # Two languages
-        
-        # Check JavaScript issues
-        js_result = next(r for r in result if r['language'] == 'JavaScript')
-        assert len(js_result['issues']) == 1
-        assert js_result['issues'][0]['title'] == 'Issue 3'
+        assert len(result) == 3
+        assert [issue["language"] for issue in result] == ["JavaScript", "Python", "Python"]
+        assert [issue["comments"] for issue in result] == [3, 2, 5]
 
-        # Check Python issues (should be sorted by comments)
-        py_result = next(r for r in result if r['language'] == 'Python')
-        assert len(py_result['issues']) == 2
-        assert py_result['issues'][0]['comments'] == 2  # First should have fewer comments
-        assert py_result['issues'][1]['comments'] == 5  # Second should have more comments
-
-    def test_render_template(self, tmp_path):
-        # Create a temporary template file
+    def test_render_template(self, tmp_path, monkeypatch):
         template_dir = tmp_path / "templates"
         template_dir.mkdir()
+
         template_file = template_dir / "README.md.j2"
-        template_content = """# Good First Issues ({{ today }})
+        template_file.write_text(
+            "{% for issue in results %}{{ issue.repo }}|{{ issue.language }}|{{ issue.title }}|{{ issue.url }}|{{ issue.comments }}\n{% endfor %}",
+            encoding="utf-8",
+        )
 
-{% for lang in results %}
-## {{ lang.language }}
-{% for issue in lang.issues %}
-- [{{ issue.title }}]({{ issue.url }}) ({{ issue.comments }} comments)
-{% endfor %}
-{% endfor %}"""
-        template_file.write_text(template_content)
+        csv_path = tmp_path / "issues.csv"
+        csv_path.write_text(
+            "repo,language,title,url,comments,labels,state\n"
+            "owner/repo,Python,A|B,https://example.com,2,[],open\n",
+            encoding="utf-8",
+        )
 
-        results = [
-            {
-                'language': 'Python',
-                'issues': [
-                    {
-                        'title': 'Test Issue',
-                        'url': 'https://example.com',
-                        'comments': 5
-                    }
-                ]
-            }
-        ]
+        monkeypatch.chdir(tmp_path)
 
-        today = "2024-03-01"
-        
-        # Create a temporary output file
-        output_file = tmp_path / "README.md"
-        
-        # Only mock the write to README.md
-        def mock_open_wrapper(original_open):
-            def wrapped_open(*args, **kwargs):
-                if args[0] == "README.md":
-                    mock_file = MagicMock()
-                    mock_file.write = MagicMock()
-                    return mock_file
-                return original_open(*args, **kwargs)
-            return wrapped_open
-        
-        with patch('builtins.open', side_effect=mock_open_wrapper(open)) as mock_open:
-            rendered = TemplateManager().render_template(results, str(template_dir), today)
+        rendered = TemplateManager().render_template(
+            str(csv_path),
+            str(template_dir),
+            "2026-07-07",
+        )
 
-            # Normalize whitespace for comparison
-            def normalize_whitespace(text):
-                # Remove empty lines and normalize remaining whitespace
-                lines = [line.strip() for line in text.splitlines() if line.strip()]
-                return '\n'.join(lines)
-
-            rendered_normalized = normalize_whitespace(rendered)
-            expected_normalized = normalize_whitespace("""# Good First Issues (2024-03-01)
-
-## Python
-- [Test Issue](https://example.com) (5 comments)""")
-
-            assert rendered_normalized == expected_normalized
-            
-            # Verify the write to README.md
-            write_calls = [call for call in mock_open.call_args_list if call[0][0] == "README.md"]
-            assert len(write_calls) == 1
-            assert write_calls[0][0][1] == "w+"
-
+        assert "owner/repo|Python|A\\|B|https://example.com|2" in rendered
+        assert (tmp_path / "README.md").read_text(encoding="utf-8") == rendered

--- a/app/tests/test_update_issues.py
+++ b/app/tests/test_update_issues.py
@@ -1,170 +1,74 @@
-import pytest
-from unittest.mock import patch, MagicMock
-import datetime
-import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
+from app.core.api_handler import IssueManager, RepoManager, TemplateManager
 from app.update_issues import main
-from app.core.api_handler import RepoManager, IssueManager, TemplateManager, Utils
 
 
-@pytest.fixture
-def mock_session():
-    with patch('requests.Session') as mock:
+def test_main_collects_issues_and_writes_output():
+    repo_url = "https://api.github.com/repos/owner/repo1"
+    raw_issue = {
+        "repository_url": repo_url,
+        "title": "Test Issue",
+        "html_url": "https://github.com/owner/repo1/issues/1",
+        "comments": 5,
+        "labels": [{"name": "good first issue"}],
+        "state": "open",
+    }
+
+    args = SimpleNamespace(output="issues.csv")
+
+    with patch("requests.Session") as mock_session_class, \
+         patch("app.update_issues.USERNAMES", ["owner"]), \
+         patch.object(RepoManager, "extract_repos", return_value={repo_url: "Python"}), \
+         patch.object(IssueManager, "extract_issues_by_user", return_value=[raw_issue]), \
+         patch.object(TemplateManager, "format_response", side_effect=lambda issues: issues) as mock_format, \
+         patch.object(TemplateManager, "write_output") as mock_write:
+
         session = MagicMock()
-        mock.return_value.__enter__.return_value = session
-        yield session
+        mock_session_class.return_value.__enter__.return_value = session
 
+        main(args)
 
-def test_main_flow(mock_session, mock_env_vars):
-    # Mock the repository data
-    repos = [
-        "https://api.github.com/repos/owner/repo1",
-        "https://api.github.com/repos/owner/repo2"
-    ]
-    
-    # Mock the raw issues data
-    raw_issues = [
-        ("Python", {
-            "repository_url": "https://api.github.com/repos/owner/repo1",
-            "title": "Test Issue 1",
-            "html_url": "https://github.com/owner/repo1/issues/1",
-            "comments": 5
-        }),
-        ("JavaScript", {
-            "repository_url": "https://api.github.com/repos/owner/repo2",
-            "title": "Test Issue 2",
-            "html_url": "https://github.com/owner/repo2/issues/2",
-            "comments": 3
-        })
-    ]
-    
-    # Mock the processed issues
-    processed_issues = [
-        {
-            "repo": "owner/repo1",
-            "language": "Python",
-            "title": "Test Issue 1",
-            "url": "https://github.com/owner/repo1/issues/1",
-            "comments": 5
-        },
-        {
-            "repo": "owner/repo2",
-            "language": "JavaScript",
-            "title": "Test Issue 2",
-            "url": "https://github.com/owner/repo2/issues/2",
-            "comments": 3
-        }
-    ]
-    
-    # Mock the formatted response
-    formatted_response = [
-        {
-            'language': 'JavaScript',
-            'issues': [{
-                "repo": "owner/repo2",
-                "language": "JavaScript",
-                "title": "Test Issue 2",
-                "url": "https://github.com/owner/repo2/issues/2",
-                "comments": 3
-            }]
-        },
-        {
-            'language': 'Python',
-            'issues': [{
+        session.headers.update.assert_called_once()
+        formatted_issues = mock_format.call_args.args[0]
+
+        assert formatted_issues == [
+            {
                 "repo": "owner/repo1",
                 "language": "Python",
-                "title": "Test Issue 1",
+                "title": "Test Issue",
                 "url": "https://github.com/owner/repo1/issues/1",
-                "comments": 5
-            }]
-        }
-    ]
-    
-    # Mock all the necessary components
-    with patch.object(RepoManager, 'extract_repos', return_value=repos), \
-         patch.object(Utils, 'create_list_from_lists', side_effect=[repos, raw_issues]), \
-         patch.object(IssueManager, 'extract_issues', return_value=raw_issues), \
-         patch.object(IssueManager, 'extract_issue_data', side_effect=lambda x: {
-             "repo": x[1]["repository_url"].split('repos/')[1],
-             "language": x[0],
-             "title": x[1]["title"],
-             "url": x[1]["html_url"],
-             "comments": x[1]["comments"]
-         }), \
-         patch.object(TemplateManager, 'format_response', return_value=formatted_response) as mock_format, \
-         patch.object(TemplateManager, 'render_template') as mock_render:
-        
-        # Run the main function
-        main()
-        
-        # Verify the session was configured correctly
-        mock_session.headers.update.assert_called_once()
-        
-        # Verify format_response was called with processed issues
-        mock_format.assert_called_once()
-        format_args = mock_format.call_args[0][0]
-        assert len(format_args) == 2
-        assert any(issue["repo"] == "owner/repo1" for issue in format_args)
-        assert any(issue["repo"] == "owner/repo2" for issue in format_args)
-        
-        # Verify render_template was called with formatted response
-        mock_render.assert_called_once()
-        render_kwargs = mock_render.call_args[1]
-        assert render_kwargs["results"] == formatted_response
-        assert "template_path" in render_kwargs
-        assert "today" in render_kwargs
-        assert render_kwargs["today"] == datetime.datetime.today().strftime('%Y-%m-%d')
+                "comments": 5,
+                "labels": ["good first issue"],
+                "state": "open",
+            }
+        ]
+        mock_write.assert_called_once_with(formatted_issues, "issues.csv")
 
 
-def test_main_with_no_repos(mock_session, mock_env_vars):
-    with patch.object(RepoManager, 'extract_repos', return_value=[]), \
-         patch.object(IssueManager, 'extract_issues') as mock_extract_issues, \
-         patch.object(TemplateManager, 'format_response') as mock_format, \
-         patch.object(TemplateManager, 'render_template') as mock_render:
-        
-        # Run the main function
-        main()
-        
-        # Verify no issues were extracted since there were no repos
-        mock_extract_issues.assert_not_called()
-        
-        # Verify template was still rendered (but with empty results)
-        mock_format.assert_called_once_with([])
-        mock_render.assert_called_once()
+def test_main_uses_other_language_when_repo_language_missing():
+    raw_issue = {
+        "repository_url": "https://api.github.com/repos/owner/missing",
+        "title": "Unknown Language Issue",
+        "html_url": "https://github.com/owner/missing/issues/1",
+        "comments": 0,
+    }
 
+    args = SimpleNamespace(output="issues.csv")
 
-def test_main_with_no_issues(mock_session, mock_env_vars):
-    repos = ["https://api.github.com/repos/owner/repo1"]
-    
-    with patch.object(RepoManager, 'extract_repos', return_value=repos), \
-         patch.object(IssueManager, 'extract_issues', return_value=[]), \
-         patch.object(TemplateManager, 'format_response') as mock_format, \
-         patch.object(TemplateManager, 'render_template') as mock_render:
-        
-        # Run the main function
-        main()
-        
-        # Verify template was rendered with empty results
-        mock_format.assert_called_once_with([])
-        mock_render.assert_called_once()
+    with patch("requests.Session") as mock_session_class, \
+         patch("app.update_issues.USERNAMES", ["owner"]), \
+         patch.object(RepoManager, "extract_repos", return_value={}), \
+         patch.object(IssueManager, "extract_issues_by_user", return_value=[raw_issue]), \
+         patch.object(TemplateManager, "format_response", side_effect=lambda issues: issues) as mock_format, \
+         patch.object(TemplateManager, "write_output") as mock_write:
 
+        session = MagicMock()
+        mock_session_class.return_value.__enter__.return_value = session
 
-def test_main_script_execution(mock_session, mock_env_vars, monkeypatch):
-    # Mock time.perf_counter to return predictable values
-    counter = 0
-    def mock_perf_counter():
-        nonlocal counter
-        counter += 1
-        return counter
-    monkeypatch.setattr('time.perf_counter', mock_perf_counter)
-    
-    # Mock logging to capture the output
-    mock_logger = MagicMock()
-    monkeypatch.setattr('logging.info', mock_logger)
-    
-    # Import and run the script's __main__ block
-    import runpy
-    runpy.run_module('app.update_issues', run_name='__main__')
-    
-    # Verify logging was called with runtime
-    mock_logger.assert_called_with('Script runtime: 1') 
+        main(args)
+
+        formatted_issues = mock_format.call_args.args[0]
+        assert formatted_issues[0]["language"] == "Other"
+        mock_write.assert_called_once_with(formatted_issues, "issues.csv")


### PR DESCRIPTION
## Summary

Repairs stale tests so they match the current issue-fetching behavior.

This PR updates tests only. No production code was changed.

## What changed

- Added the missing `mock_env_vars` fixture.
- Updated `RepoManager.extract_repos` expectations to match the current dict return shape.
- Replaced stale `IssueManager.extract_language` / `extract_issues` tests with `extract_issues_by_user` tests.
- Updated `extract_issue_data` expectations for `labels` and `state`.
- Updated `TemplateManager.format_response` expectations for the current flat sorted list behavior.
- Updated `TemplateManager.render_template` test to use a temporary CSV input path.
- Replaced stale `update_issues.main` tests so they pass args and patch current methods.

## Validation

    python -m py_compile app/update_issues.py app/core/api_handler.py app/render_readme.py app/tests/conftest.py app/tests/test_api_handler.py app/tests/test_update_issues.py
    python -m pytest app/tests -q

Result:

    17 passed

## Notes

This is a test-only repair. The goal is to restore local validation against the current source behavior without changing runtime code.
