### PR TITLE
Use column names instead of hardcoded indexes

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,6 +266,9 @@
     function updateTable() {
 
         const header = issuesData[0];
+        const languageIndex = header.indexOF("language");
+        const commentsIndex = header.indexOF(comments");
+
         let rows = issuesData.slice(1);
 
         if (currentSearch !== "") {
@@ -276,17 +279,17 @@
 
         if (currentLanguage !== "") {
             rows = rows.filter(row => {
-                return row[1] === currentLanguage
+                return row[languageIndex] === currentLanguage;
             });
         }
 
         if (sortMode === 1) {
             rows.sort(
-                (a,b) => Number(b[4]) - Number(a[4])
+                (a,b) => Number(b[commentsIndex]) - Number(a[commentsIndex])
             );
         } else if (sortMode === 2) {
             rows.sort(
-                (a,b) => Number(a[4]) - Number(b[4])
+                (a,b) => Number(a[commentsIndex]) - Number(b[commentsIndex])
             );
         }
 


### PR DESCRIPTION
## What does this PR do?

This pull request replaces hardcoded column indexes with column names when filtering and sorting issues. Instead of accessing fixed indexes (such as `row[1]` and `row[4]`), it retrieves the correct indexes from the CSV header. This makes the code more maintainable and prevents issues if the column order changes.

## Related Issue

Closes #108

## Checklist

- [x] I read the CONTRIBUTING.md
- [x] I ran the project locally and tested my changes
- [x] I verified my changes are working as expected
- [ ] This PR description is written by me, not by AI


