### PR TITLE
Add created_at and updated_at fields to action usage

### DIFF
--- a/docs/action-usage.md
+++ b/docs/action-usage.md
@@ -51,6 +51,9 @@ Each issue in the output contains the following fields:
 | `comments` | Number of comments on the issue |
 | `labels` | Labels assigned to the issue |
 | `state` | Issue state |
+| `created_at` | Timestamp of when the issue was created |
+| `updated_at` | Timestamp of when the issue was last updated |
+
 
 ### CSV Example
 


### PR DESCRIPTION
Added created_at and updated_at fields to issue details.

## What does this PR do?
<!-- Explain briefly in your own words -->

## Related Issue
<!-- Link the issue: Fixes #XX -->

## Checklist
- [ ] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I ran the project locally and tested my changes
- [ ] I verified my changes are working as expected
- [ ] This PR description is written by me, not by AI
