### PR TITLE
Fix CSV column lookup using header names

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,11 +222,15 @@
     let currentSearch = "";
     let currentLanguage = "";
     let sortMode = 0;
+
     /*
         0 = DEFAULT
         1 = DESCENDING
         2 = ASCENDING
     */
+
+    let languageIndex = -1;
+    let commentsIndex = -1;
 
     const $ = (id) => document.getElementById(id);
     const searchBox = $("searchBox");
@@ -242,119 +246,204 @@
             const tr = document.createElement("tr");
 
             row.forEach(col => {
-                const cell = document.createElement(index === 0 ? "th" : "td")
+                const cell = document.createElement(index === 0 ? "th" : "td");
 
                 if (typeof col === "string" && col.startsWith("http")) {
-                const a = document.createElement("a");
+                    const a = document.createElement("a");
 
-                a.href = col;
-                a.innerText = "Open Issue";
-                a.target = "_blank";
+                    a.href = col;
+                    a.innerText = "Open Issue";
+                    a.target = "_blank";
 
-                cell.appendChild(a);
-            } else {
-                cell.innerText = col;
-            }
-            tr.appendChild(cell);
+                    cell.appendChild(a);
+                } else {
+                    cell.innerText = col;
+                }
+
+                tr.appendChild(cell);
             });
 
             table.appendChild(tr);
         });
-
     }
+
 
     function updateTable() {
 
         const header = issuesData[0];
         let rows = issuesData.slice(1);
 
+
         if (currentSearch !== "") {
             rows = rows.filter(row => {
-                return row.join(" ").toLowerCase().includes(currentSearch.toLowerCase())
+                return row.join(" ")
+                    .toLowerCase()
+                    .includes(currentSearch.toLowerCase());
             });
         }
+
 
         if (currentLanguage !== "") {
             rows = rows.filter(row => {
-                return row[1] === currentLanguage
+                return row[languageIndex] === currentLanguage;
             });
         }
 
+
         if (sortMode === 1) {
             rows.sort(
-                (a,b) => Number(b[4]) - Number(a[4])
+                (a, b) =>
+                    Number(b[commentsIndex]) -
+                    Number(a[commentsIndex])
             );
-        } else if (sortMode === 2) {
+        } 
+        else if (sortMode === 2) {
             rows.sort(
-                (a,b) => Number(a[4]) - Number(b[4])
+                (a, b) =>
+                    Number(a[commentsIndex]) -
+                    Number(b[commentsIndex])
             );
         }
+
 
         renderTable([header, ...rows]);
     }
 
+
     searchBox.addEventListener("input", () => {
+
         currentSearch = searchBox.value;
 
-         updateTable();
+        updateTable();
+
     });
 
+
     languageFilter.addEventListener("change", () => {
+
         currentLanguage = languageFilter.value;
 
         updateTable();
-    })
+
+    });
+
 
     sortComments.addEventListener("click", () => {
-        sortMode = (sortMode +1) % 3;
+
+        sortMode = (sortMode + 1) % 3;
 
         switch (sortMode) {
+
             case 0:
                 sortComments.textContent = "Sort by comments";
                 break;
 
             case 1:
-                sortComments.textContent = "Comments Descending"
+                sortComments.textContent = "Comments Descending";
                 break;
+
             case 2:
-                sortComments.textContent = "Comments Ascending"
+                sortComments.textContent = "Comments Ascending";
                 break;
+
         }
 
         updateTable();
-    })
+
+    });
+
 
     fetch("good_first_issues.csv")
+
         .then(response => response.text())
+
         .then(csvText => {
 
             Papa.parse(csvText, {
+
                 skipEmptyLines: true,
+
                 complete: function(results) {
+
                     issuesData = results.data;
+
+
+                    if (issuesData.length === 0) {
+                        console.error("CSV is empty");
+                        return;
+                    }
+
+
+                    /*
+                        Resolve column indexes dynamically
+                        from CSV header names.
+                    */
+
+                    const headers = issuesData[0]
+                        .map(header => header.toLowerCase().trim());
+
+
+                    languageIndex =
+                        headers.indexOf("language");
+
+                    commentsIndex =
+                        headers.indexOf("comments");
+
+
+                    if (languageIndex === -1) {
+                        console.error(
+                            "CSV does not contain a language column"
+                        );
+                    }
+
+
+                    if (commentsIndex === -1) {
+                        console.error(
+                            "CSV does not contain a comments column"
+                        );
+                    }
+
 
                     const languages = [
                         ...new Set(
-                            issuesData.slice(1).map(row => row[1])
+                            issuesData
+                                .slice(1)
+                                .map(row => row[languageIndex])
+                                .filter(Boolean)
                         )
                     ];
 
+
                     languages.forEach(lang => {
-                        const option = document.createElement("option");
+
+                        const option =
+                            document.createElement("option");
 
                         option.value = lang;
                         option.textContent = lang;
 
                         languageFilter.appendChild(option);
+
                     });
 
-                    renderTable(issuesData)
+
+                    updateTable();
+
                 }
+
             });
+
         })
+
         .catch(err => {
-            console.error("Error loading CSV:", err);
+
+            console.error(
+                "Error loading CSV:",
+                err
+            );
+
         });
+
 </script>
 
 </body>


### PR DESCRIPTION
## What does this PR do?

Fixes CSV column handling by resolving column indexes from the CSV header instead of relying on hardcoded indexes.

Previously, the frontend used fixed positions like `row[1]` for language and `row[4]` for comments. If the CSV column order changed, filtering and sorting could silently break.

This change dynamically finds the required columns from the header row, making the frontend more robust against CSV structure changes.

## Related Issue

Fixes #108

## Checklist

- [x] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran the project locally and tested my changes
- [x] I verified my changes are working as expected
- [ ] This PR description is written by me, not by AI