### PR TITLE
fix: use CSV header to resolve column indices dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,10 +263,17 @@
 
     }
 
+    function getColumnIndex(header, columnName) {
+        return header.indexOf(columnName);
+    }
+
     function updateTable() {
 
         const header = issuesData[0];
         let rows = issuesData.slice(1);
+
+        const languageIdx = getColumnIndex(header, "language");
+        const commentsIdx = getColumnIndex(header, "comments");
 
         if (currentSearch !== "") {
             rows = rows.filter(row => {
@@ -276,17 +283,17 @@
 
         if (currentLanguage !== "") {
             rows = rows.filter(row => {
-                return row[1] === currentLanguage
+                return row[languageIdx] === currentLanguage
             });
         }
 
         if (sortMode === 1) {
             rows.sort(
-                (a,b) => Number(b[4]) - Number(a[4])
+                (a,b) => Number(b[commentsIdx]) - Number(a[commentsIdx])
             );
         } else if (sortMode === 2) {
             rows.sort(
-                (a,b) => Number(a[4]) - Number(b[4])
+                (a,b) => Number(a[commentsIdx]) - Number(b[commentsIdx])
             );
         }
 
@@ -333,9 +340,12 @@
                 complete: function(results) {
                     issuesData = results.data;
 
+                    const header = issuesData[0];
+                    const languageIdx = getColumnIndex(header, "language");
+
                     const languages = [
                         ...new Set(
-                            issuesData.slice(1).map(row => row[1])
+                            issuesData.slice(1).map(row => row[languageIdx])
                         )
                     ];
 


### PR DESCRIPTION
## What does this PR do?
This PR replaces hardcoded CSV column indexes (e.g. row[1]) with dynamic lookups based on the header row. 

The `getColumnIndex` helper resolves the position of "language" and "comments" at runtime, so filtering & sorting will not break silently if the CSV column order changes. 

These references are updated: 

- the language filter, 
- both comment sort comparisons, 
- and the language dropdown population.

## Related Issue
Fixes #108

## Checklist
- [x] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran the project locally and tested my changes
- [x] I verified my changes are working as expected
- [x] This PR description is written by me, not by AI
