### PR TITLE
fix: drop redundant state column and filter out assigned issues

### DIFF
--- a/app/core/api_handler.py
+++ b/app/core/api_handler.py
@@ -65,7 +65,6 @@ class IssueManager:
             issue['url'] = raw_issue[1]['html_url']
             issue['comments'] = raw_issue[1]['comments']
             issue['labels'] = [l['name'] for l in raw_issue[1].get('labels', [])]
-            issue['state'] = raw_issue[1].get('state', 'open')
             # Keep only the date part (YYYY-MM-DD) of the ISO 8601 timestamps.
             issue['created_at'] = raw_issue[1].get('created_at', '')[:10]
             issue['updated_at'] = raw_issue[1].get('updated_at', '')[:10]
@@ -83,7 +82,7 @@ class IssueManager:
         for a specific user/organization.
         """
         issues = []
-        search_url = f"https://api.github.com/search/issues?q=user:{user}+label:\"{labels}\"+state:open+is:issue&per_page=100"
+        search_url = f"https://api.github.com/search/issues?q=user:{user}+label:\"{labels}\"+state:open+is:issue+no:assignee&per_page=100"
         
         resp_json = APIClient().make_request(search_url, session)
         try:
@@ -167,7 +166,6 @@ class TemplateManager:
                         'url',
                         'comments',
                         'labels',
-                        'state',
                         'created_at',
                         'updated_at',
                     ]

--- a/app/tests/test_api_handler.py
+++ b/app/tests/test_api_handler.py
@@ -91,7 +91,6 @@ class TestIssueManager:
                 "html_url": "https://github.com/owner/repo/issues/1",
                 "comments": 5,
                 "labels": [{"name": "good first issue"}],
-                "state": "open",
                 "created_at": "2026-05-20T12:34:56Z",
                 "updated_at": "2026-07-29T08:00:00Z",
             }
@@ -106,7 +105,6 @@ class TestIssueManager:
             "url": "https://github.com/owner/repo/issues/1",
             "comments": 5,
             "labels": ["good first issue"],
-            "state": "open",
             "created_at": "2026-05-20",
             "updated_at": "2026-07-29",
         }
@@ -131,7 +129,10 @@ class TestIssueManager:
 
         assert len(result) == 1
         assert result[0]["title"] == "Test Issue"
-        mock_api_instance.make_request.assert_called_once()
+        mock_api_instance.make_request.assert_called_once_with(
+            "https://api.github.com/search/issues?q=user:test_user+label:\"good first issue\"+state:open+is:issue+no:assignee&per_page=100",
+            mock_api_instance
+        )
 
     @patch('app.core.api_handler.APIClient')
     def test_extract_issues_by_user_error(self, mock_api_client):
@@ -307,7 +308,6 @@ class TestTemplateManager:
                 'url': 'https://example.com',
                 'comments': 5,
                 'labels': ['good first issue'],
-                'state': 'open',
                 'created_at': '2024-01-01',
                 'updated_at': '2024-01-02',
             }
@@ -320,6 +320,9 @@ class TestTemplateManager:
             content = f.read()
         assert "owner/repo" in content
         assert "Python" in content
+        header = content.splitlines()[0]
+        assert "state" not in header
+        assert header == "repo,language,title,url,comments,labels,created_at,updated_at"
 
     def test_write_output_json(self, tmp_path):
         import json

--- a/app/tests/test_update_issues.py
+++ b/app/tests/test_update_issues.py
@@ -39,7 +39,6 @@ def test_main_flow(mock_session, mock_env_vars, mock_args):
             "html_url": "https://github.com/owner/repo1/issues/1",
             "comments": 5,
             "labels": [{"name": "good first issue"}],
-            "state": "open",
             "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-02T00:00:00Z",
         },
@@ -49,7 +48,6 @@ def test_main_flow(mock_session, mock_env_vars, mock_args):
             "html_url": "https://github.com/owner/repo2/issues/2",
             "comments": 3,
             "labels": [{"name": "good first issue"}],
-            "state": "open",
             "created_at": "2026-01-03T00:00:00Z",
             "updated_at": "2026-01-04T00:00:00Z",
         },
@@ -64,7 +62,6 @@ def test_main_flow(mock_session, mock_env_vars, mock_args):
              "url": x[1]["html_url"],
              "comments": x[1]["comments"],
              "labels": [l["name"] for l in x[1].get("labels", [])],
-             "state": x[1].get("state", "open"),
              "created_at": x[1].get("created_at", "")[:10],
              "updated_at": x[1].get("updated_at", "")[:10],
          }), \
@@ -116,7 +113,6 @@ def test_main_with_output(mock_session, mock_env_vars):
             "html_url": "https://github.com/owner/repo1/issues/1",
             "comments": 5,
             "labels": [{"name": "good first issue"}],
-            "state": "open",
             "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-02T00:00:00Z",
         },
@@ -134,7 +130,6 @@ def test_main_with_output(mock_session, mock_env_vars):
              "url": x[1]["html_url"],
              "comments": x[1]["comments"],
              "labels": [l["name"] for l in x[1].get("labels", [])],
-             "state": x[1].get("state", "open"),
              "created_at": x[1].get("created_at", "")[:10],
              "updated_at": x[1].get("updated_at", "")[:10],
          }), \
@@ -162,7 +157,6 @@ def test_update_issues_main_block(monkeypatch):
              "html_url": "https://github.com/owner/repo/issues/1",
              "comments": 0,
              "labels": [],
-             "state": "open",
              "created_at": "2026-01-01T00:00:00Z",
              "updated_at": "2026-01-01T00:00:00Z",
          }]), \

--- a/docs/action-usage.md
+++ b/docs/action-usage.md
@@ -50,13 +50,12 @@ Each issue in the output contains the following fields:
 | `url` | Direct link to the issue on GitHub |
 | `comments` | Number of comments on the issue |
 | `labels` | Labels assigned to the issue |
-| `state` | Issue state |
 
 ### CSV Example
 
 ```
-repo,language,title,url,comments,labels,state
-pytorch/glow,C++,Add layout propagation to NodeGen,https://github.com/pytorch/glow/issues/3834,0,['good first issue'],open
+repo,language,title,url,comments,labels
+pytorch/glow,C++,Add layout propagation to NodeGen,https://github.com/pytorch/glow/issues/3834,0,['good first issue']
 ```
 
 ### JSON Example
@@ -69,8 +68,7 @@ pytorch/glow,C++,Add layout propagation to NodeGen,https://github.com/pytorch/gl
     "title": "Add layout propagation to NodeGen",
     "url": "https://github.com/pytorch/glow/issues/3834",
     "comments": 0,
-    "labels": ["good first issue"],
-    "state": "open"
+    "labels": ["good first issue"]
   }
 ]
 ```


### PR DESCRIPTION
## Description

This Pull Request addresses issue #132 and issue #131:

### Changes Included:
1. **Drop redundant `state` column (Fixes #132)**:
   - `state` is always `"open"` because only open issues are queried. Removing it frees up horizontal width in CSV outputs and markdown tables.
   - Removed `issue['state']` from `IssueManager.extract_issue_data` and from CSV `fieldnames` in `TemplateManager.write_output`.
   - Updated documentation schema and examples in `docs/action-usage.md`.

2. **Filter out assigned issues (Fixes #131)**:
   - Added `no:assignee` to the search query URL in `IssueManager.extract_issues_by_user` so issues that already have an assignee are skipped.

### Testing & Verification:
- Updated unit test suite in `app/tests/test_api_handler.py` and `app/tests/test_update_issues.py`.
- Verified query construction and CSV header assertions.
- Ran `pytest --cov=app` locally with all 27 tests passing and 100% test coverage.
