### PR TITLE
Remove reductant state column from CSV output.

### DIFF
--- a/app/core/api_handler.py
+++ b/app/core/api_handler.py
@@ -65,7 +65,6 @@ class IssueManager:
             issue['url'] = raw_issue[1]['html_url']
             issue['comments'] = raw_issue[1]['comments']
             issue['labels'] = [l['name'] for l in raw_issue[1].get('labels', [])]
-            issue['state'] = raw_issue[1].get('state', 'open')
             # Keep only the date part (YYYY-MM-DD) of the ISO 8601 timestamps.
             issue['created_at'] = raw_issue[1].get('created_at', '')[:10]
             issue['updated_at'] = raw_issue[1].get('updated_at', '')[:10]
@@ -167,7 +166,6 @@ class TemplateManager:
                         'url',
                         'comments',
                         'labels',
-                        'state',
                         'created_at',
                         'updated_at',
                     ]

--- a/app/tests/test_api_handler.py
+++ b/app/tests/test_api_handler.py
@@ -106,7 +106,6 @@ class TestIssueManager:
             "url": "https://github.com/owner/repo/issues/1",
             "comments": 5,
             "labels": ["good first issue"],
-            "state": "open",
             "created_at": "2026-05-20",
             "updated_at": "2026-07-29",
         }
@@ -307,7 +306,6 @@ class TestTemplateManager:
                 'url': 'https://example.com',
                 'comments': 5,
                 'labels': ['good first issue'],
-                'state': 'open',
                 'created_at': '2024-01-01',
                 'updated_at': '2024-01-02',
             }

--- a/docs/action-usage.md
+++ b/docs/action-usage.md
@@ -50,13 +50,12 @@ Each issue in the output contains the following fields:
 | `url` | Direct link to the issue on GitHub |
 | `comments` | Number of comments on the issue |
 | `labels` | Labels assigned to the issue |
-| `state` | Issue state |
 
 ### CSV Example
 
 ```
-repo,language,title,url,comments,labels,state
-pytorch/glow,C++,Add layout propagation to NodeGen,https://github.com/pytorch/glow/issues/3834,0,['good first issue'],open
+repo,language,title,url,comments,labels
+pytorch/glow,C++,Add layout propagation to NodeGen,https://github.com/pytorch/glow/issues/3834,0,['good first issue']
 ```
 
 ### JSON Example
@@ -69,8 +68,7 @@ pytorch/glow,C++,Add layout propagation to NodeGen,https://github.com/pytorch/gl
     "title": "Add layout propagation to NodeGen",
     "url": "https://github.com/pytorch/glow/issues/3834",
     "comments": 0,
-    "labels": ["good first issue"],
-    "state": "open"
+    "labels": ["good first issue"]
   }
 ]
 ```


### PR DESCRIPTION
Closes #132

Removes the `state` column since it's always "open" (we only ever search open issues). Updated `extract_issue_data` and `write_output` in `api_handler.py`, plus the related test assertions in `test_api_handler.py`.