### PR TITLE
ci: add test and coverage workflow for pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run tests with coverage
+        run: pytest --cov=app --cov-report=term-missing --cov-report=xml
+
+      - name: Enforce coverage threshold
+        run: coverage report --fail-under=100

--- a/app/tests/test_update_issues.py
+++ b/app/tests/test_update_issues.py
@@ -169,6 +169,7 @@ def test_update_issues_main_block(monkeypatch):
          patch('requests.Session') as mock_sess:
         mock_sess.return_value.__enter__.return_value = MagicMock()
 
+        sys.modules.pop('app.update_issues', None)
         import runpy
         runpy.run_module('app.update_issues', run_name='__main__', alter_sys=True)
 


### PR DESCRIPTION
## What does this PR do?
Adds a CI workflow (`.github/workflows/tests.yml`) that runs `pytest` with coverage on every pull request and push to `main`. This ensures PRs can't be merged if tests fail or coverage drops below 100%.

Added some additional features (open to discussion for these):

- `concurrency group` — cancels redundant workflow runs when you push again to the same PR
- Python version matrix (3.12 + 3.13) — catches version-specific bugs
- `cache: pip` — caches dependencies for faster CI runs
- `--cov-report=xml `— produces coverage.xml (ready for Codecov etc integration later)


## Related Issue
Fixes #130

## Checklist
- [x] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran the project locally and tested my changes
- [x] I verified my changes are working as expected
- [x] This PR description is written by me, not by AI