### PR TITLE
fix: prevent CI push failure on concurrent runs

### DIFF
--- a/.github/workflows/update-issues.yml
+++ b/.github/workflows/update-issues.yml
@@ -49,4 +49,5 @@ jobs:
 
           git diff --staged --quiet || git commit -m "chore: update good first issues [skip ci]"
 
+          git pull --rebase origin main
           git push origin main


### PR DESCRIPTION
## What does this PR do?

Adds `git pull --rebase origin main` before `git push origin main` in the update-issues workflow. This prevents non-fast-forward push failures when two merges land within the workflow's ~2.5-minute runtime — the local commit is rebased onto the latest remote state before pushing.

## Related Issue
Fixes #141

## Checklist
- [x] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I ran the project locally and tested my changes
- [x] I verified my changes are working as expected
- [x] This PR description is written by me, not by AI
