### PR TITLE
fix: handle empty issue results without raising IndexError

### DIFF
--- a/app/tests/test_update_issues.py
+++ b/app/tests/test_update_issues.py
@@ -86,10 +86,8 @@ def test_main_flow(mock_session, mock_env_vars, mock_args):
 def test_main_with_no_repos(mock_session, mock_env_vars, mock_args):
     with patch.object(RepoManager, 'extract_repos', return_value={}), \
          patch.object(IssueManager, 'extract_issues_by_user', return_value=[]):
-
-        # Current code raises IndexError when no issues are found (issues[0])
-        with pytest.raises(IndexError):
-            main(mock_args)
+        # Verify that empty issue results are handled without raising an exception
+        main(mock_args)
 
 
 def test_main_with_no_issues(mock_session, mock_env_vars, mock_args):
@@ -97,10 +95,8 @@ def test_main_with_no_issues(mock_session, mock_env_vars, mock_args):
 
     with patch.object(RepoManager, 'extract_repos', return_value=repos), \
          patch.object(IssueManager, 'extract_issues_by_user', return_value=[]):
-
-        # Current code raises IndexError when no issues are found (issues[0])
-        with pytest.raises(IndexError):
-            main(mock_args)
+        # Verify that empty issue results are handled without raising an exception
+        main(mock_args)
 
 
 def test_main_with_output(mock_session, mock_env_vars):

--- a/app/tests/test_update_issues.py
+++ b/app/tests/test_update_issues.py
@@ -85,19 +85,26 @@ def test_main_flow(mock_session, mock_env_vars, mock_args):
 
 def test_main_with_no_repos(mock_session, mock_env_vars, mock_args):
     with patch.object(RepoManager, 'extract_repos', return_value={}), \
-         patch.object(IssueManager, 'extract_issues_by_user', return_value=[]):
+         patch.object(IssueManager, 'extract_issues_by_user', return_value=[]), \
+         patch.object(TemplateManager, 'format_response') as mock_format:
+
         # Verify that empty issue results are handled without raising an exception
         main(mock_args)
+
+        mock_format.assert_called_once_with([])
 
 
 def test_main_with_no_issues(mock_session, mock_env_vars, mock_args):
     repos = {"https://api.github.com/repos/owner/repo1": "Python"}
 
     with patch.object(RepoManager, 'extract_repos', return_value=repos), \
-         patch.object(IssueManager, 'extract_issues_by_user', return_value=[]):
+         patch.object(IssueManager, 'extract_issues_by_user', return_value=[]), \
+         patch.object(TemplateManager, 'format_response') as mock_format:
+
         # Verify that empty issue results are handled without raising an exception
         main(mock_args)
 
+        mock_format.assert_called_once_with([])
 
 def test_main_with_output(mock_session, mock_env_vars):
     """Test main() when args.output is set (covers write_output branch)."""

--- a/app/update_issues.py
+++ b/app/update_issues.py
@@ -52,7 +52,10 @@ def main(args):
         logging.info("Normalizing data...")
         issues = [IssueManager().extract_issue_data(issue) for issue in all_raw_issues]
         logging.info(f"Normalized data.")
-        logging.info(f"First issues row: {issues[0]}")
+        if issues:
+            logging.info(f"First issues row: {issues[0]}")
+        else:
+            logging.info("No issues found.")
 
         formatted_response = TemplateManager.format_response(issues)
 


### PR DESCRIPTION
## Description

Fixes the IndexError that occurred when no issues were returned by the GitHub Search API.

Previously, the code accessed `issues[0]` without checking whether the list was empty.

This change:
- Handles empty issue results safely
- Logs a message when no issues are found
- Updates the existing tests to verify that no exception is raised

## Testing

- `pytest -v` → 27 passed
- `git diff --check` → no errors