### PR TITLE
fix: truncate the long table values

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
     const COLUMNS = [
         { key: "repo",       label: "Repo" },
         { key: "language",   label: "Language" },
-        { key: "title",      label: "Title" },
+        { key: "title",      label: "Title", truncate: 90 },
         { key: "url",        label: "URL",      render: "link", linkText: "Open Issue" },
         { key: "comments",   label: "Comments", sortable: true, numeric: true },
         { key: "labels",     label: "Labels" },
@@ -303,6 +303,9 @@
                     a.innerText = col.linkText || value;
                     a.target = "_blank";
                     td.appendChild(a);
+                }else if (col.truncate && value.length > col.truncate) {
+                    td.innerText = value.slice(0, col.truncate).trimEnd() + "…";
+                    td.title = value;
                 } else {
                     td.innerText = value;
                 }

--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
                     a.innerText = col.linkText || value;
                     a.target = "_blank";
                     td.appendChild(a);
-                }else if (col.truncate && value.length > col.truncate) {
+                } else if (col.truncate && value.length > col.truncate) {
                     td.innerText = value.slice(0, col.truncate).trimEnd() + "…";
                     td.title = value;
                 } else {


### PR DESCRIPTION
## What does this PR do?
* The problem will solve the a handful of very long titles (i.e up to 185 chars) were forcing horizontal scroll on the whole table. 
* And my approach is picked the cutoff from the data (medium 55 / p90 90) rather than guessing, added the truncate to the column model since it didn't have one sliced the display text and put the full title in the title of the csv file.
* And the fixed the issue [#148](https://github.com/drkrillo/good-first-issues/issues/148)

## Related Issue
Closes #148 

## Checklist
* [x] I read the CONTRIBUTING.md
* [x] I ran the project locally and tested my changes
* [x] I verified my changes are working as expected
* [x] This PR description is written by me, not by AI
