### PR TITLE
Add max_age_days filter to search_issues

### DIFF
--- a/app/core/dataset.py
+++ b/app/core/dataset.py
@@ -2,6 +2,7 @@ import ast
 import csv
 
 from app.core.custom_exceptions import DatasetError
+from datetime import date, timedelta
 
 import logging
 from collections import defaultdict
@@ -58,13 +59,15 @@ class DatasetManager:
 
     @staticmethod
     def filter_issues(issues, language=None, max_comments=None,
-                      label=None, repo=None, limit=20):
+                      label=None, repo=None, limit=20, max_age_days: int | None = None):
         """
         Takes a list of issues and the filters to apply, and returns the
         matching ones sorted by comment count, least discussed first.
-        """
-        results = issues
 
+        max_age_days filters on the updated_at, inclusive of boundary. 
+        Issues with no updated_at are excluded, since recency can't be verified for them.   
+        """
+        results = issues       
         if language:
             results = [i for i in results
                        if i['language'].lower() == language.lower()]
@@ -75,6 +78,15 @@ class DatasetManager:
                        if any(label.lower() == l.lower() for l in i['labels'])]
         if repo:
             results = [i for i in results if repo.lower() in i['repo'].lower()]
+        if max_age_days is not None:
+            cutoff = date.today() - timedelta(days=max_age_days)
+            filtered = []
+            for i in results:
+                if not i['updated_at']:
+                    continue  
+                if date.fromisoformat(i['updated_at']) >= cutoff:
+                    filtered.append(i)
+            results = filtered
 
         sorted_results = sorted(results, key=lambda i: i['comments'])
         return sorted_results[:limit]

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -29,6 +29,7 @@ def search_issues(
     label: str | None = None,
     repo: str | None = None,
     limit: int = 20,
+    max_age_days: int | None = None
 ) -> list[dict]:
     """
     Search the good first issues dataset, least discussed issues first.
@@ -37,6 +38,11 @@ def search_issues(
     the ones least likely to be claimed already. The language must match one
     reported by list_languages. The repo filter matches on a substring of
     owner/name, so "django" finds every Django repository at once.
+
+    Set max_age_days to only return issues updated within that many days.
+    An issue labeled good first issue that nobody has touched in years is
+    not really available, and this dataset has plenty of those — use this
+    filter when the goal is a currently active issue, not just any match.
     """
     return DatasetManager.filter_issues(
         load_dataset(),
@@ -45,6 +51,7 @@ def search_issues(
         label=label,
         repo=repo,
         limit=limit,
+        max_age_days=max_age_days
     )
 
 

--- a/app/tests/test_dataset.py
+++ b/app/tests/test_dataset.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from datetime import date, timedelta
+
 from app.core.config import get_dataset_path
 from app.core.dataset import DatasetManager
 from app.core.custom_exceptions import DatasetError
@@ -126,6 +128,44 @@ class TestFilterIssues:
         result = DatasetManager.filter_issues(issues, limit=1)
 
         assert len(result) == 1
+
+    def test_filter_issues_boundary_case(self, tmp_path):
+        updated_at = date.today().isoformat()
+        created_at = (date.today() - timedelta(days=200)).isoformat()
+        csv_content = (
+            CSV_HEADER +
+            f'owner/recent,Python,Fresh issue,https://github.com/owner/recent/issues/1,'
+            f'0,"[\'good first issue\']",{updated_at},{updated_at}\n'
+            f'owner/old,Python,Stale issue,https://github.com/owner/old/issues/2,'
+            f'0,"[\'good first issue\']",{created_at},{created_at}\n'
+        )
+        csv_file = tmp_path / 'issues.csv'
+        csv_file.write_text(csv_content, encoding='utf-8')
+        issues = DatasetManager.load_issues(str(csv_file))
+        result = DatasetManager.filter_issues(issues, max_age_days=0)
+        assert len(result) == 1
+        assert result[0]['repo'] == 'owner/recent'
+
+    def test_filter_issues_empty_updated_at(self, tmp_path):
+            updated_at = date.today().isoformat()
+            created_at = (date.today() - timedelta(days=200)).isoformat()
+            csv_content = (
+                CSV_HEADER +
+                f'owner/empty_updated_at,Python,Fresh issue,https://github.com/owner/recent/issues/1,'
+                f'0,"[\'good first issue\']",{created_at},\n'
+                f'owner/with_updated_at,Python,Stale issue,https://github.com/owner/old/issues/2,'
+                f'0,"[\'good first issue\']",{created_at},{updated_at}\n'
+            )
+            csv_file = tmp_path / 'issues.csv'
+            csv_file.write_text(csv_content, encoding='utf-8')
+            issues = DatasetManager.load_issues(str(csv_file))
+            result = DatasetManager.filter_issues(issues, max_age_days=0)
+            assert len(result) == 1
+            assert result[0]['repo'] == 'owner/with_updated_at'
+
+    def test_filter_issues_without_max_age_days(self, issues):
+        result = DatasetManager.filter_issues(issues, max_age_days=None)
+        assert len(result) == len(issues)
 
 
 class TestCountByLanguage:

--- a/app/tests/test_mcp_server.py
+++ b/app/tests/test_mcp_server.py
@@ -6,7 +6,6 @@ from datetime import date, timedelta
 import pytest
 
 from mcp.server.mcpserver import MCPServer
-from app.core.dataset import DatasetManager
 
 
 from app import mcp_server

--- a/app/tests/test_mcp_server.py
+++ b/app/tests/test_mcp_server.py
@@ -1,10 +1,13 @@
 import asyncio
 import sys
 from unittest.mock import patch
+from datetime import date, timedelta
 
 import pytest
 
 from mcp.server.mcpserver import MCPServer
+from app.core.dataset import DatasetManager
+
 
 from app import mcp_server
 
@@ -55,6 +58,29 @@ class TestSearchIssues:
         assert len(result) == 1
         assert result[0]['repo'] == 'owner/alpha'
 
+    def test_search_issues_with_filter_max_age_days(self, tmp_path, monkeypatch):
+
+        updated_at = date.today().isoformat()
+        created_at = (date.today() - timedelta(days=200)).isoformat()
+        csv_content = (
+            CSV_HEADER +
+            f'owner/recent,Python,Fresh issue,https://github.com/owner/recent/issues/1,'
+            f'0,"[\'good first issue\']",{updated_at},{updated_at}\n'
+            f'owner/old,Python,Stale issue,https://github.com/owner/old/issues/2,'
+            f'0,"[\'good first issue\']",{created_at},{created_at}\n'
+        )
+        csv_file = tmp_path / 'issues.csv'
+        csv_file.write_text(csv_content, encoding='utf-8')
+        monkeypatch.setenv('ISSUES_CSV', str(csv_file)) 
+        result = mcp_server.search_issues(
+            max_age_days=0
+        )
+
+        assert len(result) == 1
+        assert result[0]['repo'] == 'owner/recent'
+
+        
+
 
 class TestListLanguages:
 
@@ -98,7 +124,7 @@ class TestToolRegistration:
 
         search = next(t for t in tools if t.name == 'search_issues')
         assert set(search.input_schema['properties']) == {
-            'language', 'max_comments', 'label', 'repo', 'limit',
+            'language', 'max_comments', 'label', 'repo', 'limit', 'max_age_days',
         }
 
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -63,7 +63,7 @@ dependencies into, otherwise the server starts without them.
 
 | Tool | Arguments | Returns |
 |---|---|---|
-| `search_issues` | `language`, `max_comments`, `label`, `repo`, `limit` | Matching issues, least discussed first |
+| `search_issues` | `language`, `max_comments`, `label`, `repo`, `limit`, `max_age_days` | Matching issues, least discussed first |
 | `list_languages` | — | Languages in the dataset, with issue counts |
 | `list_repositories` | `language` | Repositories in the dataset, with issue counts |
 
@@ -82,6 +82,11 @@ All arguments are optional.
 - **`repo`** — Matches a substring of `owner/name`, so `django` finds every
   Django repository at once.
 - **`limit`** — How many issues to return. Defaults to 20.
+- **`max_age_days`** — Only return issues updated within this many days.
+  Filters on `updated_at`, inclusive of the boundary, so `0` means "updated
+  today." Issues with no `updated_at` are excluded, since recency can't be
+  verified for them. Use this to avoid surfacing issues nobody has actually
+  touched in years.
 
 Results are always sorted by comment count, least discussed first, on the
 assumption that a quiet issue is a free one.


### PR DESCRIPTION
## What does this PR do?
Filtering the issues on the basis of updated_at so that only issues which are active will be searched, also the max_age_days is inclusive of the boundary to ensure if it is set 0 it will return the issues opened or updated today.

Issues with empty updated_at are excluded when max_age_days is set, since we can't verify the recency of the issue and the whole point of this feature is filtering out the stale issues.

Added 4 new tests covering basic age filtering, inclusive boundary case,  empty updated_at exclusion and when max_age_days not passed.

Full suite passes, 100% coverage maintained. 

## Related Issue
Fixes #155

## Checklist

- [ x ] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ x ] I ran the project locally and tested my changes
- [ x ] I verified my changes are working as expected
- [ x ] This PR description is written by me, not by AI
