### PR TITLE
feat(mcp): fall back to published dataset when local file is missing

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -66,8 +66,12 @@ Grouped in classes, one per component:
 
 The MCP tools, each against a dataset written to `tmp_path` and pointed at with
 `ISSUES_CSV`: `search_issues` with and without filters, `list_languages`,
-`list_repositories`, that the three tools are registered and described for the
-model, and the `__main__` block.
+`list_repositories`, `dataset_info`, that all four tools are registered and
+described for the model, and the `__main__` block. `load_dataset` is also
+covered without a local
+file: the published CSV is fetched through a mocked `requests.get` (never a
+real request), including cache hits, expiry, stale-cache fallback, and fetch
+errors.
 
 ### `app/tests/test_update_issues.py`
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,6 +23,13 @@ HEADERS = {
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+PUBLISHED_DATASET_URL = (
+    'https://raw.githubusercontent.com/drkrillo/good-first-issues/'
+    'main/good_first_issues.csv'
+)
+DATASET_FETCH_TIMEOUT = 10
+DATASET_CACHE_TTL_SECONDS = 3600
+
 
 def get_template_path():
     return os.path.join(BASE_DIR, 'templates')

--- a/app/core/custom_exceptions.py
+++ b/app/core/custom_exceptions.py
@@ -23,21 +23,26 @@ class APIError(Exception):
 
 class DatasetError(Exception):
     """
-    Exception Handling for a missing issues dataset.
-    
+    Exception Handling for a missing or unreachable issues dataset.
+
     Input:
-    path: The path the dataset was expected to be found at.
+    path: The path or URL the dataset was expected to be found at.
+    reason: Optional extra detail, used when a fetch fails.
     """
-    def __init__(self, path):
+    def __init__(self, path, reason=None):
         self.path = path
-        self.custom_message = (
-            f"DatasetError: no issues dataset at {path}. "
-            f"Run update_issues.py first, or point ISSUES_CSV at one."
-        )
-        
+        self.reason = reason
+        if reason:
+            self.custom_message = f"DatasetError: {reason}"
+        else:
+            self.custom_message = (
+                f"DatasetError: no issues dataset at {path}. "
+                f"Run update_issues.py first, or point ISSUES_CSV at one."
+            )
+
         logging.error(self.custom_message)
-        
+
         super().__init__(self.custom_message)
-        
+
     def __str__(self):
         return self.custom_message

--- a/app/core/dataset.py
+++ b/app/core/dataset.py
@@ -1,5 +1,6 @@
 import ast
 import csv
+import io
 
 from app.core.custom_exceptions import DatasetError
 from datetime import date, timedelta
@@ -30,32 +31,43 @@ class DatasetManager:
         return [label.strip() for label in raw_labels.split(';') if label.strip()]
 
     @staticmethod
+    def _issues_from_reader(reader):
+        issues = []
+        for row in reader:
+            issues.append({
+                'repo': row['repo'],
+                'language': row['language'],
+                'title': row['title'],
+                'url': row['url'],
+                'comments': int(row['comments']),
+                'labels': DatasetManager.parse_labels(row.get('labels', '')),
+                'created_at': row.get('created_at', ''),
+                'updated_at': row.get('updated_at', ''),
+            })
+        return issues
+
+    @staticmethod
     def load_issues(csv_path):
         """
         Takes the path of the dataset written by the pipeline and returns
         its issues, with the comment count as an int and the labels as a list.
         """
-        issues = []
         try:
             with open(csv_path, newline='', encoding='utf-8') as f:
-                reader = csv.DictReader(f)
-
-                for row in reader:
-                    issues.append({
-                        'repo': row['repo'],
-                        'language': row['language'],
-                        'title': row['title'],
-                        'url': row['url'],
-                        'comments': int(row['comments']),
-                        'labels': DatasetManager.parse_labels(row.get('labels', '')),
-                        'created_at': row.get('created_at', ''),
-                        'updated_at': row.get('updated_at', ''),
-                    })
+                return DatasetManager._issues_from_reader(csv.DictReader(f))
         except FileNotFoundError as error:
             logging.error(error)
             raise DatasetError(csv_path) from error
 
-        return issues
+    @staticmethod
+    def load_issues_from_text(csv_text):
+        """
+        Takes the CSV contents as text and returns the same issue dicts
+        as load_issues.
+        """
+        return DatasetManager._issues_from_reader(
+            csv.DictReader(io.StringIO(csv_text))
+        )
 
     @staticmethod
     def filter_issues(issues, language=None, max_comments=None,

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -1,6 +1,17 @@
+import logging
+import os
+import time
+
+import requests
 from mcp.server.mcpserver import MCPServer
 
-from app.core.config import get_dataset_path
+from app.core.config import (
+    DATASET_CACHE_TTL_SECONDS,
+    DATASET_FETCH_TIMEOUT,
+    PUBLISHED_DATASET_URL,
+    get_dataset_path,
+)
+from app.core.custom_exceptions import DatasetError
 from app.core.dataset import DatasetManager
 
 
@@ -8,18 +19,104 @@ mcp = MCPServer(
     name='good-first-issues',
     instructions=(
         'Search the good first issues dataset this repository builds. '
-        'The data is whatever the pipeline last wrote locally, so it follows '
-        'the usernames this checkout is configured for. Call list_languages '
-        'before search_issues to see which languages are actually present.'
+        'The data is ISSUES_CSV if that is set, otherwise the local CSV '
+        'if it is present, otherwise the published dataset on GitHub. '
+        'Call dataset_info to see which of those answered. Call '
+        'list_languages before search_issues to see which languages are '
+        'actually present.'
     ),
 )
+
+_published_cache = {
+    'issues': None,
+    'fetched_at': 0.0,
+}
+
+_dataset_meta = {
+    'source': None,
+    'location': None,
+}
+
+
+def _remember_source(source, location):
+    _dataset_meta['source'] = source
+    _dataset_meta['location'] = location
+
+
+def _fetch_published_dataset():
+    response = requests.get(
+        PUBLISHED_DATASET_URL,
+        timeout=DATASET_FETCH_TIMEOUT,
+    )
+    response.raise_for_status()
+    return DatasetManager.load_issues_from_text(response.text)
 
 
 def load_dataset():
     """
-    Returns the issues held in the dataset the pipeline last wrote.
+    Returns the issues to search.
+
+    Resolution order: ISSUES_CSV if set, then the local file if it is
+    there, then the published CSV. The published copy is cached so
+    tool calls do not fetch on every request. The source in use is
+    stored for dataset_info.
     """
-    return DatasetManager.load_issues(get_dataset_path())
+    env_path = os.environ.get('ISSUES_CSV')
+    if env_path:
+        logging.info('Loading issues dataset from ISSUES_CSV (%s)', env_path)
+        issues = DatasetManager.load_issues(env_path)
+        _remember_source('ISSUES_CSV', env_path)
+        return issues
+
+    local_path = get_dataset_path()
+    if os.path.isfile(local_path):
+        logging.info('Loading issues dataset from local file (%s)', local_path)
+        issues = DatasetManager.load_issues(local_path)
+        _remember_source('local', local_path)
+        return issues
+
+    now = time.monotonic()
+    cached = _published_cache['issues']
+    fetched_at = _published_cache['fetched_at']
+    cache_is_fresh = (
+        cached is not None
+        and (now - fetched_at) < DATASET_CACHE_TTL_SECONDS
+    )
+    if cache_is_fresh:
+        logging.info(
+            'Loading issues dataset from published cache (%s)',
+            PUBLISHED_DATASET_URL,
+        )
+        _remember_source('published', PUBLISHED_DATASET_URL)
+        return cached
+
+    try:
+        issues = _fetch_published_dataset()
+    except requests.RequestException as error:
+        if cached is not None:
+            logging.warning(
+                'Fetch of published dataset failed (%s); using stale cache',
+                error,
+            )
+            _remember_source('published', PUBLISHED_DATASET_URL)
+            return cached
+        raise DatasetError(
+            PUBLISHED_DATASET_URL,
+            reason=(
+                f"no local dataset at {local_path}, and fetching the "
+                f"published dataset from {PUBLISHED_DATASET_URL} failed: "
+                f"{error}"
+            ),
+        ) from error
+
+    _published_cache['issues'] = issues
+    _published_cache['fetched_at'] = now
+    logging.info(
+        'Loading issues dataset from published file (%s)',
+        PUBLISHED_DATASET_URL,
+    )
+    _remember_source('published', PUBLISHED_DATASET_URL)
+    return issues
 
 
 @mcp.tool()
@@ -71,6 +168,21 @@ def list_repositories(language: str | None = None) -> list[dict]:
     most issues first, optionally narrowed to a single language.
     """
     return DatasetManager.count_by_repo(load_dataset(), language=language)
+
+
+@mcp.tool()
+def dataset_info() -> dict:
+    """
+    Which dataset the other tools are reading.
+
+    source is ISSUES_CSV, local, or published. location is the file path
+    or the published URL.
+    """
+    load_dataset()
+    return {
+        'source': _dataset_meta['source'],
+        'location': _dataset_meta['location'],
+    }
 
 
 if __name__ == '__main__':

--- a/app/tests/test_dataset.py
+++ b/app/tests/test_dataset.py
@@ -77,6 +77,15 @@ class TestLoadIssues:
         with pytest.raises(DatasetError):
             DatasetManager.load_issues(missing)
 
+    def test_load_issues_from_text_matches_load_issues(self, dataset_file):
+        with open(dataset_file, encoding='utf-8') as f:
+            csv_text = f.read()
+
+        from_text = DatasetManager.load_issues_from_text(csv_text)
+        from_file = DatasetManager.load_issues(dataset_file)
+
+        assert from_text == from_file
+
 
 class TestFilterIssues:
 
@@ -202,6 +211,15 @@ class TestDatasetError:
         error = DatasetError('/tmp/missing.csv')
 
         assert '/tmp/missing.csv' in str(error)
+
+    def test_dataset_error_uses_the_fetch_reason(self):
+        error = DatasetError(
+            'https://example.com/issues.csv',
+            reason='no local dataset, and fetching failed: timed out',
+        )
+
+        assert 'timed out' in str(error)
+        assert error.reason == 'no local dataset, and fetching failed: timed out'
 
 
 class TestConfig:

--- a/app/tests/test_mcp_server.py
+++ b/app/tests/test_mcp_server.py
@@ -1,14 +1,16 @@
 import asyncio
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from datetime import date, timedelta
 
 import pytest
+import requests
 
 from mcp.server.mcpserver import MCPServer
 
-
 from app import mcp_server
+from app.core.config import DATASET_CACHE_TTL_SECONDS, PUBLISHED_DATASET_URL
+from app.core.custom_exceptions import DatasetError
 
 
 CSV_HEADER = 'repo,language,title,url,comments,labels,created_at,updated_at\n'
@@ -29,6 +31,26 @@ def dataset_env(tmp_path, monkeypatch):
     return str(csv_file)
 
 
+@pytest.fixture(autouse=True)
+def reset_published_cache():
+    mcp_server._published_cache['issues'] = None
+    mcp_server._published_cache['fetched_at'] = 0.0
+    mcp_server._dataset_meta['source'] = None
+    mcp_server._dataset_meta['location'] = None
+    yield
+    mcp_server._published_cache['issues'] = None
+    mcp_server._published_cache['fetched_at'] = 0.0
+    mcp_server._dataset_meta['source'] = None
+    mcp_server._dataset_meta['location'] = None
+
+
+def _published_response(text=None):
+    response = MagicMock()
+    response.text = text if text is not None else CSV_HEADER + CSV_ROWS
+    response.raise_for_status.return_value = None
+    return response
+
+
 class TestLoadDataset:
 
     def test_load_dataset_reads_the_configured_file(self, dataset_env):
@@ -36,6 +58,147 @@ class TestLoadDataset:
 
         assert len(result) == 2
         assert result[0]['repo'] == 'owner/alpha'
+        assert 'dataset_source' not in result[0]
+
+    def test_load_dataset_does_not_fetch_when_issues_csv_is_missing(
+        self, tmp_path, monkeypatch
+    ):
+        missing = tmp_path / 'nope.csv'
+        monkeypatch.setenv('ISSUES_CSV', str(missing))
+
+        with patch('app.mcp_server.requests.get') as mock_get:
+            with pytest.raises(DatasetError):
+                mcp_server.load_dataset()
+
+        mock_get.assert_not_called()
+
+    def test_load_dataset_reads_the_local_file_when_env_is_unset(
+        self, tmp_path, monkeypatch
+    ):
+        csv_file = tmp_path / 'good_first_issues.csv'
+        csv_file.write_text(CSV_HEADER + CSV_ROWS, encoding='utf-8')
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(mcp_server, 'get_dataset_path', lambda: str(csv_file))
+
+        with patch('app.mcp_server.requests.get') as mock_get:
+            result = mcp_server.load_dataset()
+
+        mock_get.assert_not_called()
+        assert result[0]['repo'] == 'owner/alpha'
+
+    def test_load_dataset_fetches_the_published_file_when_nothing_local(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(
+            mcp_server, 'get_dataset_path', lambda: str(tmp_path / 'missing.csv')
+        )
+
+        with patch(
+            'app.mcp_server.requests.get', return_value=_published_response()
+        ) as mock_get:
+            result = mcp_server.load_dataset()
+
+        mock_get.assert_called_once_with(
+            PUBLISHED_DATASET_URL,
+            timeout=mcp_server.DATASET_FETCH_TIMEOUT,
+        )
+        assert len(result) == 2
+        assert result[0]['repo'] == 'owner/alpha'
+
+    def test_load_dataset_reuses_the_published_cache(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(
+            mcp_server, 'get_dataset_path', lambda: str(tmp_path / 'missing.csv')
+        )
+        monkeypatch.setattr(mcp_server.time, 'monotonic', lambda: 1000.0)
+
+        with patch(
+            'app.mcp_server.requests.get', return_value=_published_response()
+        ) as mock_get:
+            first = mcp_server.load_dataset()
+            second = mcp_server.load_dataset()
+
+        assert mock_get.call_count == 1
+        assert first == second
+
+    def test_load_dataset_refetches_when_the_cache_expires(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(
+            mcp_server, 'get_dataset_path', lambda: str(tmp_path / 'missing.csv')
+        )
+        current = {'t': 1000.0}
+        monkeypatch.setattr(mcp_server.time, 'monotonic', lambda: current['t'])
+
+        with patch(
+            'app.mcp_server.requests.get', return_value=_published_response()
+        ) as mock_get:
+            mcp_server.load_dataset()
+            current['t'] = 1000.0 + DATASET_CACHE_TTL_SECONDS + 1
+            mcp_server.load_dataset()
+
+        assert mock_get.call_count == 2
+
+    def test_load_dataset_uses_stale_cache_when_a_refetch_fails(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(
+            mcp_server, 'get_dataset_path', lambda: str(tmp_path / 'missing.csv')
+        )
+        current = {'t': 1000.0}
+        monkeypatch.setattr(mcp_server.time, 'monotonic', lambda: current['t'])
+
+        with patch(
+            'app.mcp_server.requests.get',
+            side_effect=[
+                _published_response(),
+                requests.exceptions.ConnectionError('offline'),
+            ],
+        ) as mock_get:
+            first = mcp_server.load_dataset()
+            current['t'] = 1000.0 + DATASET_CACHE_TTL_SECONDS + 1
+            second = mcp_server.load_dataset()
+
+        assert mock_get.call_count == 2
+        assert second[0]['repo'] == first[0]['repo']
+
+    def test_load_dataset_errors_when_the_published_fetch_fails(
+        self, tmp_path, monkeypatch
+    ):
+        missing = tmp_path / 'missing.csv'
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(mcp_server, 'get_dataset_path', lambda: str(missing))
+
+        with patch(
+            'app.mcp_server.requests.get',
+            side_effect=requests.exceptions.Timeout('timed out'),
+        ):
+            with pytest.raises(DatasetError) as excinfo:
+                mcp_server.load_dataset()
+
+        message = str(excinfo.value)
+        assert str(missing) in message
+        assert PUBLISHED_DATASET_URL in message
+        assert 'timed out' in message
+
+    def test_load_dataset_errors_on_an_http_failure(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(
+            mcp_server, 'get_dataset_path', lambda: str(tmp_path / 'missing.csv')
+        )
+        response = MagicMock()
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            '404'
+        )
+
+        with patch('app.mcp_server.requests.get', return_value=response):
+            with pytest.raises(DatasetError) as excinfo:
+                mcp_server.load_dataset()
+
+        assert '404' in str(excinfo.value)
 
 
 class TestSearchIssues:
@@ -111,7 +274,10 @@ class TestToolRegistration:
         tools = asyncio.run(mcp_server.mcp.list_tools())
 
         names = {tool.name for tool in tools}
-        assert names == {'search_issues', 'list_languages', 'list_repositories'}
+        assert names == {
+            'search_issues', 'list_languages', 'list_repositories',
+            'dataset_info',
+        }
 
     def test_every_tool_is_described_for_the_model(self):
         tools = asyncio.run(mcp_server.mcp.list_tools())
@@ -125,6 +291,44 @@ class TestToolRegistration:
         assert set(search.input_schema['properties']) == {
             'language', 'max_comments', 'label', 'repo', 'limit', 'max_age_days',
         }
+
+
+class TestDatasetInfo:
+
+    def test_dataset_info_reports_issues_csv(self, dataset_env):
+        info = mcp_server.dataset_info()
+
+        assert info['source'] == 'ISSUES_CSV'
+        assert info['location'] == dataset_env
+
+    def test_dataset_info_reports_local(self, tmp_path, monkeypatch):
+        csv_file = tmp_path / 'good_first_issues.csv'
+        csv_file.write_text(CSV_HEADER + CSV_ROWS, encoding='utf-8')
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(
+            mcp_server, 'get_dataset_path', lambda: str(csv_file)
+        )
+
+        info = mcp_server.dataset_info()
+
+        assert info['source'] == 'local'
+        assert info['location'] == str(csv_file)
+
+    def test_dataset_info_reports_published(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('ISSUES_CSV', raising=False)
+        monkeypatch.setattr(
+            mcp_server, 'get_dataset_path',
+            lambda: str(tmp_path / 'missing.csv'),
+        )
+
+        with patch(
+            'app.mcp_server.requests.get',
+            return_value=_published_response(),
+        ):
+            info = mcp_server.dataset_info()
+
+        assert info['source'] == 'published'
+        assert info['location'] == PUBLISHED_DATASET_URL
 
 
 def test_mcp_server_main_block(monkeypatch):

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -4,9 +4,15 @@ The project ships an [MCP](https://modelcontextprotocol.io) server, so an AI
 assistant can query the issues dataset directly instead of you reading the
 table by hand.
 
-It reads the dataset **the pipeline last wrote on this machine**, so it answers
-with the usernames this checkout is configured for, not with the ones in the
-upstream repository.
+It reads the dataset in this order: `ISSUES_CSV` if that is set, then
+`good_first_issues.csv` at the project root if that file is present, then
+the [published copy](https://raw.githubusercontent.com/drkrillo/good-first-issues/main/good_first_issues.csv)
+the daily action writes to `main`. A checkout that already has a local CSV
+keeps using it. Somebody who has neither still gets the curated list instead
+of an error.
+
+Call `dataset_info` to see which copy answered (`ISSUES_CSV`, `local`, or
+`published`) and its file path or URL.
 
 ## Prerequisites
 
@@ -18,14 +24,16 @@ does not pull it for nothing:
 pip install -r requirements-mcp.txt
 ```
 
-Then generate a dataset:
+A local dataset is optional. If you want the server to follow the usernames
+this checkout is configured for, generate one:
 
 ```bash
 python -m app.update_issues --output good_first_issues.csv
 ```
 
-The server reads `good_first_issues.csv` at the root of the project. Point it
-somewhere else with the `ISSUES_CSV` environment variable.
+Otherwise it fetches the published CSV (cached for an hour, ten second
+timeout). Point it at a specific file with the `ISSUES_CSV` environment
+variable.
 
 ## Running it
 
@@ -66,6 +74,7 @@ dependencies into, otherwise the server starts without them.
 | `search_issues` | `language`, `max_comments`, `label`, `repo`, `limit`, `max_age_days` | Matching issues, least discussed first |
 | `list_languages` | — | Languages in the dataset, with issue counts |
 | `list_repositories` | `language` | Repositories in the dataset, with issue counts |
+| `dataset_info` | — | Which dataset the other tools are reading |
 
 All arguments are optional.
 


### PR DESCRIPTION
- Fall back to fetching published dataset from GitHub if local file and ISSUES_CSV are unset
- Cache published dataset with 1-hour TTL and use stale cache if refetch fails
- Add dataset_info tool to return active dataset source and location
- Add load_issues_from_text to DatasetManager
- Update tests and documentation

## What does this PR do?
My PR does now when you clone the repo locally run the MCP without running the GitHub Actions , I doesn't works since there is no CSV file is created , therefore the PR added a fallback , if there is no ISSUES_CSV file in the local folder , the server fetches the published dataset directly from the Github and caches it for an hour , so we are not calling Github for every tool call, after cached data expires and refetching is failed is keep using older data instead of crashing up,

My PR also added a dataset_info tool so you can check from where the actual data are coming like env var ,local file or from the url , and a load_issues_from_text helper on DatasetManager for parsing CSV from a string instead of a file.

## Related Issue
<!-- Link the issue: Fixes #XX -->

## Checklist
- [ ✅] I read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ✅] I ran the project locally and tested my changes
- [ ✅] I verified my changes are working as expected
- [ ✅] This PR description is written by me, not by AI
